### PR TITLE
fix: remove key description from startup latency metric

### DIFF
--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/view/ApplicationStartUpDataFormatter.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/view/ApplicationStartUpDataFormatter.java
@@ -63,7 +63,6 @@ public class ApplicationStartUpDataFormatter extends DataFormatter {
     private static LabelKey getLabelKey() {
         return LabelKey.newBuilder()
                        .setKey(getName(app, start, state))
-                       .setDescription(key)
                        .build();
     }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
@@ -8,7 +8,6 @@ import io.bitrise.trace.data.trace.Trace;
 import io.opencensus.proto.metrics.v1.Metric;
 import retrofit2.Call;
 import retrofit2.http.Body;
-import retrofit2.http.Headers;
 import retrofit2.http.POST;
 
 /**
@@ -23,8 +22,7 @@ public interface NetworkCommunicator {
      * @param metricRequest the {@link MetricRequest} to send that contains the Metrics.
      * @return the result of the Call.
      */
-    @Headers("Accept: application/vnd.bitrise.trace-v1+json")
-    @POST("/api/metrics")
+    @POST("/api/v1/metrics")
     Call<Void> sendMetrics(@Body @NonNull final MetricRequest metricRequest);
 
     /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
@@ -8,6 +8,7 @@ import io.bitrise.trace.data.trace.Trace;
 import io.opencensus.proto.metrics.v1.Metric;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 
 /**
@@ -22,7 +23,8 @@ public interface NetworkCommunicator {
      * @param metricRequest the {@link MetricRequest} to send that contains the Metrics.
      * @return the result of the Call.
      */
-    @POST("/api/v1/metrics")
+    @Headers("Accept: application/vnd.bitrise.trace-v1+json")
+    @POST("/api/metrics")
     Call<Void> sendMetrics(@Body @NonNull final MetricRequest metricRequest);
 
     /**

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/metric/MetricConverterTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/metric/MetricConverterTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class MetricConverterTest {
 
-    private final String METRIC_APPLICATION_START_UP = "{\"metric_descriptor\":{\"name\":\"app.startup.latency.ms\",\"description\":\"App startup latency in milliseconds\",\"unit\":\"ms\",\"type\":1,\"label_keys\":[{\"key\":\"app.start.state\",\"description\":\"key\"}]},\"timeseries\":[{\"label_values\":[{\"value\":\"cold\"}],\"points\":[{\"value\":1234.0,\"value_case\":3,\"timestamp\":{\"seconds\":1614687783,\"nanos\":614000000}}]}]}";
+    private final String METRIC_APPLICATION_START_UP = "{\"metric_descriptor\":{\"name\":\"app.startup.latency.ms\",\"description\":\"App startup latency in milliseconds\",\"unit\":\"ms\",\"type\":1,\"label_keys\":[{\"key\":\"app.start.state\"}]},\"timeseries\":[{\"label_values\":[{\"value\":\"cold\"}],\"points\":[{\"value\":1234.0,\"value_case\":3,\"timestamp\":{\"seconds\":1614687783,\"nanos\":614000000}}]}]}";
     private final String PREVIOUS_METRIC_RECORD = "[10,91,10,22,97,112,112,46,115,116,97,114,116,117,112,46,108,97,116,101,110,99,121,46,109,115,18,35,65,112,112,32,115,116,97,114,116,117,112,32,108,97,116,101,110,99,121,32,105,110,32,109,105,108,108,105,115,101,99,111,110,100,115,26,2,109,115,32,1,42,22,10,15,97,112,112,46,115,116,97,114,116,46,115,116,97,116,101,18,3,107,101,121,18,33,18,6,10,4,99,111,108,100,26,23,10,12,8,-89,-36,-8,-127,6,16,-128,-53,-29,-92,2,25,0,0,0,0,0,72,-109,64]";
 
     /**

--- a/trace-sdk/src/test/resources/io/bitrise/trace/network/metric_request.json
+++ b/trace-sdk/src/test/resources/io/bitrise/trace/network/metric_request.json
@@ -8,8 +8,7 @@
         "type":1,
         "label_keys":[
           {
-            "key":"app.start.state",
-            "description":"key"
+            "key":"app.start.state"
           }
         ]
       },


### PR DESCRIPTION
Update the label_key description in the startup latency metric - the task said to make this an empty string, however none of the other metrics have a key description so i figured removing it entirely made sense :-)

I also had to update the metric_request.json test and the MetricConverter test.