### PR TITLE
fix: Update metric endpoint

### DIFF
--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkClient.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkClient.java
@@ -216,14 +216,12 @@ public final class NetworkClient {
         return chain -> {
             final Request request =
                     chain.request().newBuilder()
-                         .addHeader("Content-Type", "application/json")
-                         .addHeader("Accept-Language", getAcceptedLanguage())
-                         .addHeader("Connection", "keep-alive")
-                         .addHeader("Accept", "application/json")
-                         .addHeader("User-Agent", getUserAgent())
-                         .addHeader("Content-Length", getContentLength(chain))
                          .addHeader("Authorization", getAuthorizationBearer())
                          .addHeader("Accept-Encoding", "gzip;q=1.0, compress;q=0.5)")
+                         .addHeader("Accept-Language", getAcceptedLanguage())
+                         .addHeader("Connection", "keep-alive")
+                         .addHeader("Content-Length", getContentLength(chain))
+                         .addHeader("User-Agent", getUserAgent())
                          .build();
             return chain.proceed(request);
         };

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
@@ -19,6 +19,7 @@ public interface NetworkCommunicator {
 
     /**
      * Sends the given List of {@link Metric}s to the server.
+     * Note: These headers are required for the updated endpoint.
      *
      * @param metricRequest the {@link MetricRequest} to send that contains the Metrics.
      * @return the result of the Call.
@@ -32,10 +33,16 @@ public interface NetworkCommunicator {
 
     /**
      * Sends the given List of {@link Trace} to the server.
+     * Note: These headers are different to the metrics endpoint. When we have an updated endpoint
+     * for traces these should be removed and added to the NetworkClient.
      *
      * @param traceRequest the {@link TraceRequest} to send that contains the Spans.
      * @return the result of the Call.
      */
+    @Headers({
+            "Accept: application/json",
+            "Content-Type: application/json"
+    })
     @POST("/api/v1/trace")
     Call<Void> sendTraces(@Body @NonNull final TraceRequest traceRequest);
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
@@ -8,6 +8,7 @@ import io.bitrise.trace.data.trace.Trace;
 import io.opencensus.proto.metrics.v1.Metric;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 
 /**
@@ -22,7 +23,8 @@ public interface NetworkCommunicator {
      * @param metricRequest the {@link MetricRequest} to send that contains the Metrics.
      * @return the result of the Call.
      */
-    @POST("/api/v1/metrics")
+    @Headers("Accept: application/vnd.bitrise.trace-v1+json")
+    @POST("/api/metrics")
     Call<Void> sendMetrics(@Body @NonNull final MetricRequest metricRequest);
 
     /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkCommunicator.java
@@ -23,7 +23,10 @@ public interface NetworkCommunicator {
      * @param metricRequest the {@link MetricRequest} to send that contains the Metrics.
      * @return the result of the Call.
      */
-    @Headers("Accept: application/vnd.bitrise.trace-v1+json")
+    @Headers({
+            "Accept: application/vnd.bitrise.trace-v1+json",
+            "Content-Type: application/vnd.bitrise.trace-v1+json"
+    })
     @POST("/api/metrics")
     Call<Void> sendMetrics(@Body @NonNull final MetricRequest metricRequest);
 


### PR DESCRIPTION
Updated the metric endpoint and updated the new headers that are required now for this one endpoint.

Tested by making a local trace-sdk and using the pineapple app. I received the following response:
<img width="446" alt="Screenshot 2021-04-07 at 13 11 23" src="https://user-images.githubusercontent.com/71286749/113864469-d50fa300-97a2-11eb-90e7-3f64e6a43be4.png">
