### PR TITLE
build: release trace-sdk 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ trace-android-sdk public beta versions
 **Note:** these versions of the *trace-android-sdk* are stored in a public repo, but should be 
 considered still as beta.
 
+### trace-sdk - 0.1.1 - 2021-04-09
+* fix: **Update metric endpoint:** Update metric endpoint to the updated endpoint.
+* fix: **remove key description from startup latency metric:** Remove description from the label key in startup latency metric.
+
 ### trace-gradle-plugin - 0.1.0 - 2021-03-24
 * feat: **Initial public release**
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1233,7 +1233,7 @@ workflows:
               # debug log
               set -x
 
-              $BITRISE_SOURCE_DIR/gradlew "tagModule -PmoduleToTag=trace-sdk"
+              $BITRISE_SOURCE_DIR/gradlew "tagModule" "-PmoduleToTag=trace-sdk"
         title: Tag release
     - gradle-runner@1:
         inputs:
@@ -1261,7 +1261,7 @@ workflows:
             $BITRISE_SOURCE_DIR/gradlew ":trace-sdk:publishToMavenLocal"
             $BITRISE_SOURCE_DIR/gradlew -p "./trace-gradle-plugin/" publishToMavenLocal --stacktrace
             $BITRISE_SOURCE_DIR/gradlew -p "./trace-gradle-plugin/" build --stacktrace
-            $BITRISE_SOURCE_DIR/gradlew "tagModule -PmoduleToTag=trace-gradle-plugin"
+            $BITRISE_SOURCE_DIR/gradlew "tagModule" "-PmoduleToTag=trace-gradle-plugin"
             $BITRISE_SOURCE_DIR/gradlew -p "./trace-gradle-plugin/" publish --stacktrace
         title: build_&_publish_trace-gradle-plugin
     description: |-

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ task tagModule() {
 
     exec {
         commandLine("git", "tag", tagName)
-        commandLine("git", "push", "origin", tagName)
+        commandLine("git", "push", "origin", "--tags")
     }
 
     group = "trace"

--- a/trace-sdk/gradle.properties
+++ b/trace-sdk/gradle.properties
@@ -1,4 +1,4 @@
 name=trace-sdk
 group=io.bitrise.trace
-version=0.1.0
-versionCode=6
+version=0.1.1
+versionCode=7


### PR DESCRIPTION
Preparations for releasing trace-sdk 0.1.1.

Updated pineapple app to 1.5.2 to test - received the following [session]( https://app.bitrise.io/trace/f359a8234189eda8/performance/MemoryBytes/session/01F2V3KNZFQ9F803DJKETF17XT?dateFrom=1617883200999&dateTo=1617969598999)

<img width="1023" alt="Screenshot 2021-04-09 at 12 57 51" src="https://user-images.githubusercontent.com/71286749/114176601-4716f200-9933-11eb-9936-c07651c54a1c.png">
