### PR TITLE
build: prepare release trace-sdk version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ trace-android-sdk public beta versions
 **Note:** these versions of the *trace-android-sdk* are stored in a public repo, but should be 
 considered still as beta.
 
+### trace-sdk - 0.2.0 - 2021-04-15
+* feat: **Support Android version 21:** Update minSdkVersion to 21 for trace-sdk and trace-test-application
+
 ### trace-sdk - 0.1.1 - 2021-04-09
 * fix: **Update metric endpoint:** Update metric endpoint to the updated endpoint.
 * fix: **remove key description from startup latency metric:** Remove description from the label key in startup latency metric.

--- a/trace-sdk/gradle.properties
+++ b/trace-sdk/gradle.properties
@@ -1,4 +1,4 @@
 name=trace-sdk
 group=io.bitrise.trace
-version=0.1.2
+version=0.2.0
 versionCode=8

--- a/trace-sdk/gradle.properties
+++ b/trace-sdk/gradle.properties
@@ -1,4 +1,4 @@
 name=trace-sdk
 group=io.bitrise.trace
-version=0.1.1
-versionCode=7
+version=0.1.2
+versionCode=8


### PR DESCRIPTION
Preparing for the release of trace-sdk 0.2.0

Tested on pineapple app - updated version to 1.6.0 - session looks as expected:

<img width="752" alt="Screenshot 2021-04-15 at 11 37 14" src="https://user-images.githubusercontent.com/71286749/114856473-0f022a00-9ddf-11eb-859d-6900636e4146.png">
