### PR TITLE
chore: add flag to TraceSdk to increase debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ deprecated Android support libraries.
 
 ## Debug mode
 
-The TraceSdk has a debug mode - currently this will mean more debug level log messages. Note: we do not log anything if your app is in release mode. To see these log messages your app should also be in debug mode.
+The TraceSdk has a debug mode - currently this will mean more debug level log messages.
+
+Please note if you are not using a debug build, and or minify is enabled it can affect these logs, and they can be stripped out depending on your configuration
+You also need to ensure that the TraceSdk has been initialised before setting the debug enabled mode.
 
 To enable this add the following to your project e.g. in your MainActivity:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ deprecated Android support libraries.
 
 ## Debug mode
 
-The TraceSdk has a debug mode - currently this will mean more debug level log messages. 
+The TraceSdk has a debug mode - currently this will mean more debug level log messages. Note: we do not log anything if your app is in release mode. To see these log messages your app should also be in debug mode.
 
 To enable this add the following to your project e.g. in your MainActivity:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use Trace to:
 * SDK uses AndroidX libraries, there could be issues when integrating it to an app with the 
 deprecated Android support libraries.
 
-Debug mode
+## Debug mode
 
 The TraceSdk has a debug mode - currently this will mean more debug level log messages. 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Use Trace to:
 * SDK uses AndroidX libraries, there could be issues when integrating it to an app with the 
 deprecated Android support libraries.
 
+Debug mode
+
+The TraceSdk has a debug mode - currently this will mean more debug level log messages. 
+
+To enable this add the following to your project e.g. in your MainActivity:
+
+```java
+TraceSdk.setDebugEnabled(true)
+```
+
+Note: You can enable and disable debug mode anywhere in your application, this could be the first activity, or a specific activity later in the application lifecycle.
+
 ## Installation
 
 ### Using the Bitrise Step

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -41,6 +41,11 @@ public class TraceSdk {
      */
     public static final String NAME = "Trace Android";
 
+    /**
+     * Flag to configure the sdk into debug mode, by default this will be false.
+     */
+    public static boolean DEBUG_ENABLED = false;
+
     private TraceSdk() {
         // nop
     }
@@ -69,9 +74,19 @@ public class TraceSdk {
             initDataCollection(context);
             initLifeCycleListener(context);
             initNetworkTracing();
+            TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, DEBUG_ENABLED));
         } else {
             TraceLog.e(new TraceException.TraceConfigNotInitialisedException());
         }
+    }
+
+    /**
+     * Flag to enable TraceSdk into debug mode.
+     * @param debugEnabled boolean value to enable or disable debug mode in the TraceSdk.
+     */
+    public synchronized static void setDebugEnabled(boolean debugEnabled) {
+        DEBUG_ENABLED = debugEnabled;
+        TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, DEBUG_ENABLED));
     }
 
     /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -43,7 +43,8 @@ public class TraceSdk {
 
     /**
      * Flag to configure the sdk into debug mode, by default this will be false.
-     * Currently, debug mode will add more debug log messages.
+     * Currently, debug mode will add more debug log messages. Note: we do not log anything if your
+     * app is in release mode. To see these log messages your app should also be in debug mode.
      */
     private static boolean DEBUG_ENABLED = false;
 
@@ -83,6 +84,8 @@ public class TraceSdk {
 
     /**
      * Flag to enable TraceSdk into debug mode. Currently, this will add more debug log messages.
+     * Note: we do not log anything if your app is in release mode. To see these log messages your
+     * app should also be in debug mode.
      *
      * @param debugEnabled boolean value to enable or disable debug mode in the TraceSdk.
      */

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -42,9 +42,12 @@ public class TraceSdk {
     public static final String NAME = "Trace Android";
 
     /**
-     * Flag to configure the sdk into debug mode, by default this will be false.
-     * Currently, debug mode will add more debug log messages. Note: we do not log anything if your
-     * app is in release mode. To see these log messages your app should also be in debug mode.
+     * The TraceSdk has a debug mode - currently this will mean more debug level log messages.
+     *
+     * Please note if you are not using a debug build, and or minify is enabled it can affect these
+     * logs, and they can be stripped out depending on your configuration.
+     * You also need to ensure that the TraceSdk has been initialised before setting the debug
+     * enabled mode.
      */
     private static boolean DEBUG_ENABLED = false;
 
@@ -83,9 +86,12 @@ public class TraceSdk {
     }
 
     /**
-     * Flag to enable TraceSdk into debug mode. Currently, this will add more debug log messages.
-     * Note: we do not log anything if your app is in release mode. To see these log messages your
-     * app should also be in debug mode.
+     * Flag to enable debug mode - currently this will mean more debug level log messages.
+     *
+     * Please note if you are not using a debug build, and or minify is enabled it can affect these
+     * logs, and they can be stripped out depending on your configuration.
+     * You also need to ensure that the TraceSdk has been initialised before setting the debug
+     * enabled mode.
      *
      * @param debugEnabled boolean value to enable or disable debug mode in the TraceSdk.
      */

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -43,8 +43,9 @@ public class TraceSdk {
 
     /**
      * Flag to configure the sdk into debug mode, by default this will be false.
+     * Currently, debug mode will add more debug log messages.
      */
-    public static boolean DEBUG_ENABLED = false;
+    private static boolean DEBUG_ENABLED = false;
 
     private TraceSdk() {
         // nop
@@ -81,12 +82,20 @@ public class TraceSdk {
     }
 
     /**
-     * Flag to enable TraceSdk into debug mode.
+     * Flag to enable TraceSdk into debug mode. Currently, this will add more debug log messages.
+     *
      * @param debugEnabled boolean value to enable or disable debug mode in the TraceSdk.
      */
-    public synchronized static void setDebugEnabled(boolean debugEnabled) {
+    public synchronized static void setDebugEnabled(final boolean debugEnabled) {
         DEBUG_ENABLED = debugEnabled;
         TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, DEBUG_ENABLED));
+    }
+
+    /**
+     * @return whether the sdk is in debug mode.
+     */
+    public static boolean isDebugEnabled() {
+        return DEBUG_ENABLED;
     }
 
     /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
@@ -50,6 +50,7 @@ public final class LogMessageConstants {
     public static final String SET_URL_STREAM_HANDLER_FACTORY_FAILED = "setURLStreamHandlerFactory failed. This means" +
             " the Trace SDK will not be able to capture network metrics that use URLConnection. Please refer to the " +
             "documentation for further guidance.";
+    public static final String TRACE_DEBUG_FLAG_STATUS = "TraceSdk debug = %b";
     public static final String TRACE_SENDING = "Attempting to send a trace.";
     public static final String TRACE_SENT_SUCCESSFULLY = "Trace sent successfully";
     public static final String TRACE_SDK_SUCCESSFULLY_INITIALISED = "Trace SDK is successfully initialised.";

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
@@ -50,7 +50,7 @@ public final class LogMessageConstants {
     public static final String SET_URL_STREAM_HANDLER_FACTORY_FAILED = "setURLStreamHandlerFactory failed. This means" +
             " the Trace SDK will not be able to capture network metrics that use URLConnection. Please refer to the " +
             "documentation for further guidance.";
-    public static final String TRACE_DEBUG_FLAG_STATUS = "TraceSdk debug = %b";
+    public static final String TRACE_DEBUG_FLAG_STATUS = "TraceSdk debug mode enabled = %b";
     public static final String TRACE_SENDING = "Attempting to send a trace.";
     public static final String TRACE_SENT_SUCCESSFULLY = "Trace sent successfully";
     public static final String TRACE_SDK_SUCCESSFULLY_INITIALISED = "Trace SDK is successfully initialised.";

--- a/trace-test-application/build.gradle
+++ b/trace-test-application/build.gradle
@@ -36,7 +36,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "io.bitrise.trace:trace-sdk:${traceVersions.traceSdk}"
+    implementation project(path: ':trace-sdk')
 
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
     implementation "androidx.constraintlayout:constraintlayout:${versions.constraintLayout}"

--- a/trace-test-application/src/main/java/io/bitrise/trace/testapp/IndexActivity.java
+++ b/trace-test-application/src/main/java/io/bitrise/trace/testapp/IndexActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
+import io.bitrise.trace.TraceSdk;
 import io.bitrise.trace.testapp.network.NetworkActivity;
 import io.bitrise.trace.testapp.ui.MainActivity;
 
@@ -16,6 +17,8 @@ public class IndexActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_index);
+
+        TraceSdk.setDebugEnabled(true);
 
         Button btnUiTests = findViewById(R.id.btn_ui_tests);
         Button btnNetworkTests = findViewById(R.id.btn_network_tests);


### PR DESCRIPTION
This PR adds a flag `DEBUG_ENABLED` to allow customers to use TraceSdk in debug mode. I've also turned it on in the trace-test-application.

I've added some logging to tell people what state debug mode is at the start, and when it gets changed. That might look confusing to people who override it in their first activity - What do you think?

<img width="1502" alt="Screenshot 2021-04-19 at 14 30 34" src="https://user-images.githubusercontent.com/71286749/115248184-61b14e00-a11f-11eb-9541-dc5086c6bb99.png">
> example of the logs when you start the SDK