### PR TITLE
chore: unify trace versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,6 @@
 import io.bitrise.trace.internal.UpdateChangeLogTask
 
 buildscript {
-    final Properties traceGradlePluginProperties = new Properties()
-    final File traceGradlePluginPropertiesFile = new File(getProject().getRootDir().getAbsolutePath() + ("/trace-gradle-plugin/gradle.properties"))
-    traceGradlePluginPropertiesFile.withInputStream {
-        traceGradlePluginProperties.load(it)
-    }
-
-    ext.traceVersions = [
-            'traceGradlePlugin': traceGradlePluginProperties.get("version"),
-            'traceSdk'         : project(':trace-sdk').property('version')
-    ]
 
     repositories {
         mavenLocal() // To check for locally published trace-gradle-plugin artifact

--- a/opencensus/build.gradle
+++ b/opencensus/build.gradle
@@ -52,7 +52,7 @@ project.afterEvaluate {
             library(MavenPublication) {
                 from components.java
 
-                version versions.opencensus
+                version traceVersions.opencensus
 
                 pom {
                     name = 'Trace SDK internal OpenCensus module'

--- a/trace-gradle-plugin/build.gradle
+++ b/trace-gradle-plugin/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:${versions.okhttp}"){
         because "${constraintReasons.okhttp}"
     }
-    implementation "io.bitrise.trace.internal:opencensus:${versions.opencensus}"
+    implementation "io.bitrise.trace.internal:opencensus:${traceVersions.opencensus}"
     testCompileOnly "androidx.annotation:annotation:${versions.androidxAnnotation}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.mockito:mockito-core:${versions.mockitoCore}"

--- a/trace-gradle-plugin/gradle.properties
+++ b/trace-gradle-plugin/gradle.properties
@@ -1,3 +1,2 @@
 name=trace-gradle-plugin
 group=io.bitrise.trace.plugin
-version=0.1.0

--- a/trace-gradle-plugin/release-trace-plugin.gradle
+++ b/trace-gradle-plugin/release-trace-plugin.gradle
@@ -20,6 +20,8 @@ project.afterEvaluate {
     publishing {
         publications {
             pluginMaven(MavenPublication) {
+
+                version traceVersions.traceGradlePlugin
                 
                 pom {
                     name = 'Trace Android Gradle Plugin'

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -93,10 +93,8 @@ public class TraceGradlePluginFunctionalTest {
         }
 
         try {
-            FunctionalTestUtils.copyFile(TestConstants.GRADLE_PROPERTIES_FILE_NAME,
-                    testDirPath + "traceGradlePlugin.properties");
-            FunctionalTestUtils.copyFile("../trace-sdk/" + TestConstants.GRADLE_PROPERTIES_FILE_NAME,
-                    testDirPath + "traceSdk.properties");
+            FunctionalTestUtils.copyFile("../" + TestConstants.VERSIONS_GRADLE,
+                    testDirPath + TestConstants.VERSIONS_GRADLE);
             FunctionalTestUtils.copyFile(FunctionalTestUtils.getGradlePropertiesForResource(0),
                     testDirPath + TestConstants.GRADLE_PROPERTIES_FILE_NAME);
             FunctionalTestUtils.copyFile(FunctionalTestUtils.getBuildGradleForResource(0),

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/TestConstants.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/TestConstants.java
@@ -53,4 +53,9 @@ public class TestConstants {
      * The directory name for the main sources.
      */
     public static final String MAIN_SOURCE_DIRECTORY_NAME = "src/main";
+
+    /**
+     * The name for the versions.gradle file.
+     */
+    public static final String VERSIONS_GRADLE = "versions.gradle";
 }

--- a/trace-gradle-plugin/src/functionalTest/resources/0_build.gradle
+++ b/trace-gradle-plugin/src/functionalTest/resources/0_build.gradle
@@ -2,14 +2,7 @@
 // 1. not contain dependency on trace-sdk
 // 2. use the lowest supported version of com.android.tools:gradle
 buildscript {
-    // These property files are copied during the setup of TraceGradlePluginFunctionalTest
-    final Properties traceGradlePluginProperties = new Properties()
-    final File traceGradlePluginPropertiesFile = new File(getProject().getProjectDir().getAbsolutePath() + ("/traceGradlePlugin.properties"))
-    traceGradlePluginPropertiesFile.withInputStream {
-        traceGradlePluginProperties.load(it)
-    }
-    def tgpVersion = traceGradlePluginProperties.get("version")
-
+    apply from: "versions.gradle"
     repositories {
         mavenLocal()
         mavenCentral()
@@ -17,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath "io.bitrise.trace.plugin:trace-gradle-plugin:$tgpVersion"
+        classpath "io.bitrise.trace.plugin:trace-gradle-plugin:$traceVersions.traceGradlePlugin"
     }
 }
 

--- a/trace-gradle-plugin/src/functionalTest/resources/1_build.gradle
+++ b/trace-gradle-plugin/src/functionalTest/resources/1_build.gradle
@@ -1,15 +1,9 @@
 // Constraints: This build file should
 // 1. contain dependency on trace-sdk
 // 2. use the latest version of com.android.tools:gradle
+apply from: "versions.gradle"
 buildscript {
-    // These property files are copied during the setup of TraceGradlePluginFunctionalTest
-    final Properties traceGradlePluginProperties = new Properties()
-    final File traceGradlePluginPropertiesFile = new File(getProject().getProjectDir().getAbsolutePath() + ("/traceGradlePlugin.properties"))
-    traceGradlePluginPropertiesFile.withInputStream {
-        traceGradlePluginProperties.load(it)
-    }
-    def tgpVersion = traceGradlePluginProperties.get("version")
-
+    apply from: "versions.gradle"
     repositories {
         mavenLocal()
         mavenCentral()
@@ -17,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath "io.bitrise.trace.plugin:trace-gradle-plugin:$tgpVersion"
+        classpath "io.bitrise.trace.plugin:trace-gradle-plugin:$traceVersions.traceGradlePlugin"
     }
 }
 
@@ -50,15 +44,7 @@ android {
         }
     }
 }
-
-// These property files are copied during the setup of TraceGradlePluginFunctionalTest
-final Properties traceSdkProperties = new Properties()
-final File traceSdkPropertiesFile = new File(getProject().getProjectDir().getAbsolutePath() + ("/traceSdk.properties"))
-traceSdkPropertiesFile.withInputStream {
-    traceSdkProperties.load(it)
-}
-def tsVersion = traceSdkProperties.get("version")
-
+apply from: "versions.gradle"
 dependencies {
-    implementation "io.bitrise.trace:trace-sdk:$tsVersion"
+    implementation "io.bitrise.trace:trace-sdk:$traceVersions.traceSdk"
 }

--- a/trace-sdk/build.gradle
+++ b/trace-sdk/build.gradle
@@ -7,8 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode = "$project.versionCode" as int
-        versionName "$project.version"
+        versionName "$traceVersions.traceSdk"
         buildConfigField('String', 'VERSION_NAME', "\"${project.version}\"")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {
@@ -49,7 +48,7 @@ dependencies {
         version { require versions.okhttp }
         because constraintReasons.okhttp
     }
-    implementation "io.bitrise.trace.internal:opencensus:${versions.opencensus}"
+    implementation "io.bitrise.trace.internal:opencensus:${traceVersions.opencensus}"
     implementation("com.google.guava:listenablefuture:${versions.listenableFuture}"){
         because constraintReasons.guava
     }

--- a/trace-sdk/gradle.properties
+++ b/trace-sdk/gradle.properties
@@ -1,4 +1,2 @@
 name=trace-sdk
 group=io.bitrise.trace
-version=0.2.0
-versionCode=8

--- a/trace-sdk/release-trace-sdk.gradle
+++ b/trace-sdk/release-trace-sdk.gradle
@@ -44,6 +44,8 @@ project.afterEvaluate {
 
                 from components.release
 
+                version traceVersions.traceSdk
+
                 pom {
                     name = 'Trace Android SDK'
                     packaging 'aar'

--- a/versions.gradle
+++ b/versions.gradle
@@ -23,13 +23,17 @@ buildscript {
             'mockitoCore'       : '3.2.4',
             'navigation'        : '2.3.5',
             'okhttp'            : '3.14.9',
-            'opencensus'        : '1.0.1',
             'protobufJava'      : '3.14.0',
             'retrofit'          : '2.7.1',
             'room'              : '2.2.5',
             'rootbeer'          : '0.0.8',
             'uiautomator'       : '2.2.0',
             'ulidj'             : '1.0.0',
+    ]
+    ext.traceVersions = [
+            'opencensus'        : '1.0.1',
+            'traceSdk'          : '0.2.0',
+            'traceGradlePlugin' : '0.1.0'
     ]
     ext.constraintReasons = [
             'guava'   : 'to avoid guava version conflicts see https://github.com/google/guava/blob/master/futures/listenablefuture9999/pom.xml',


### PR DESCRIPTION
This PR uses the versions.gradle file to create a `traceVersions` section with all the versions used for trace projects. Updated the release scripts to ensure this variable is used correctly.