### PR TITLE
chore: Update analyse_code workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -119,6 +119,8 @@ workflows:
           title: Switch to Java 11
           inputs:
             - content: |-
+                git fetch
+
                 sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
                 sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -115,6 +115,15 @@ workflows:
             log\nset -x\n\n{\necho $GOOGLE_APPLICATION_CREDENTIALS_CONTENT > $HOME/trace-android-sa.json\n}
             &> /dev/null "
           title: Add google credentials
+      - script@1:
+          title: Switch to Java 11
+          inputs:
+            - content: |-
+                sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+                sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+
+                export JAVA_HOME='/usr/lib/jvm/java-11-openjdk-amd64'
+                envman add --key JAVA_HOME --value '/usr/lib/jvm/java-11-openjdk-amd64'
       - gradle-runner@1:
           inputs:
             - gradlew_path: "$BITRISE_SOURCE_DIR/gradlew"

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ sonarqube {
         property "sonar.projectKey", "bitrise-io_trace-android-sdk"
         property "sonar.organization", "bitrise-io"
         property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.branch.name", ".*"
+        property "sonar.branch.name", System.getenv("BITRISE_GIT_BRANCH")
         property "sonar.branch.target", "main"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -94,5 +94,7 @@ sonarqube {
         property "sonar.projectKey", "bitrise-io_trace-android-sdk"
         property "sonar.organization", "bitrise-io"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.branch.name", ".*"
+        property "sonar.branch.target", "main"
     }
 }


### PR DESCRIPTION
Updated analyse_code workflow, to switch to Java 11 before running
SonarQube. This is required by them.

APM-2912