### PR TITLE
chore: TraceGradlePluginFunctionalTest test dividers

### DIFF
--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -8,6 +8,7 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -66,7 +67,13 @@ public class TraceGradlePluginFunctionalTest {
      */
     @BeforeClass
     public static void setUpTests() {
+        functionalTestHelper.logInAsciiBox("Starting tests for " + TraceGradlePluginFunctionalTest.class.getName());
         functionalTestHelper.publishTraceGradlePlugin();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        functionalTestHelper.logInAsciiBox("Finished tests for " + TraceGradlePluginFunctionalTest.class.getName());
     }
 
     /**
@@ -74,7 +81,7 @@ public class TraceGradlePluginFunctionalTest {
      */
     @Before
     public void setUpTest() {
-        functionalTestHelper.logTestName(testName);
+        functionalTestHelper.logTestNameInAsciiBox(testName);
         functionalTestHelper.setupTestDir(testName);
         functionalTestHelper.setupLocalProperties(testName);
         functionalTestHelper.setupTraceProperties(testName);
@@ -84,10 +91,10 @@ public class TraceGradlePluginFunctionalTest {
     }
 
     /**
-     * Delete (permanently) the temporary gradle project folder, if {@link #DELETE_TEMP_PROJECT} is enabled.
+     * Delete (permanently) the temporary Gradle project folder, if {@link #DELETE_TEMP_PROJECT} is enabled.
      */
     @After
-    public void deleteTemporaryProjectAfterTest() {
+    public void tearDownTest() {
         if (DELETE_TEMP_PROJECT) {
             functionalTestHelper.deleteTemporaryProject(testName);
         }

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -87,7 +87,6 @@ public class TraceGradlePluginFunctionalTest {
     public void setUpTest() {
         functionalTestHelper.logTestNameInAsciiBox(testName);
         functionalTestHelper.setupTestDir(testName);
-        functionalTestHelper.setupLocalProperties(testName);
         functionalTestHelper.setupTraceProperties(testName);
         functionalTestHelper.setupGradleProperties(testName, 0);
         functionalTestHelper.setupBitriseAddons(testName, 0);

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -74,6 +74,7 @@ public class TraceGradlePluginFunctionalTest {
      */
     @Before
     public void setUpTest() {
+        functionalTestHelper.logTestName(testName);
         functionalTestHelper.setupTestDir(testName);
         functionalTestHelper.setupLocalProperties(testName);
         functionalTestHelper.setupTraceProperties(testName);

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -69,17 +69,17 @@ public class TraceGradlePluginFunctionalTest {
 
     /**
      * An instance of {@link FunctionalTestWriter} that will write the output of each test case to the console with
-     * cyan color.
+     * AQUA4 color from the Bitkit.
      */
     private final FunctionalTestWriter stdOutWriter = new FunctionalTestWriter(System.out,
-            FunctionalTestWriter.PrintColor.CYAN);
+            FunctionalTestWriter.PrintColor.AQUA4);
 
     /**
      * An instance of {@link FunctionalTestWriter} that will write the error of each test case to the console with
-     * magenta color.
+     * RED4 color from the Bitkit.
      */
     private final FunctionalTestWriter errWriter = new FunctionalTestWriter(System.err,
-            FunctionalTestWriter.PrintColor.MAGENTA);
+            FunctionalTestWriter.PrintColor.RED4);
 
     /**
      * Sets up the test class.

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -56,11 +56,15 @@ public class TraceGradlePluginFunctionalTest {
      */
     private static final boolean DELETE_TEMP_PROJECT = false;
 
-
     /**
      * The {@link FunctionalTestHelper} class that provides some supportive functions to the tests.
      */
     private static final FunctionalTestHelper functionalTestHelper = new FunctionalTestHelper();
+
+    /**
+     * Format for the relative path of the build ID file. The formatting arguments should be the build variant.
+     */
+    private static final String buildIdFileRelativePathFormat = "/build/outputs/apk/%s/bitriseBuildId.txt";
 
     /**
      * Sets up the test class.
@@ -96,7 +100,7 @@ public class TraceGradlePluginFunctionalTest {
     @After
     public void tearDownTest() {
         if (DELETE_TEMP_PROJECT) {
-            functionalTestHelper.deleteTemporaryProject(testName);
+            functionalTestHelper.deleteTestProjectDir(testName);
         }
     }
 
@@ -337,12 +341,12 @@ public class TraceGradlePluginFunctionalTest {
      * contains the build ID.
      */
     private void verifyGenerateBuildIdTasksForBuild() {
-        final File debugBuildIdFile =
-                new File(functionalTestHelper.getTestDir(testName)
-                                             .getPath() + "/build/outputs/apk/debug/bitriseBuildId.txt");
-        final File releaseBuildIdFile =
-                new File(functionalTestHelper.getTestDir(testName)
-                                             .getPath() + "/build/outputs/apk/release/bitriseBuildId.txt");
+        final File debugBuildIdFile = new File(
+                functionalTestHelper.getTestDir(testName).getPath() + String.format(buildIdFileRelativePathFormat,
+                        "debug"));
+        final File releaseBuildIdFile = new File(
+                functionalTestHelper.getTestDir(testName).getPath() + String.format(buildIdFileRelativePathFormat,
+                        "release"));
 
         assertThat(debugBuildIdFile.exists(), is(true));
         assertThat(releaseBuildIdFile.exists(), is(true));
@@ -353,9 +357,9 @@ public class TraceGradlePluginFunctionalTest {
      * contains the build ID.
      */
     private void verifyGenerateBuildIdTasksForAssembleDebug() {
-        final File debugBuildIdFile =
-                new File(functionalTestHelper.getTestDir(testName)
-                                             .getPath() + "/build/outputs/apk/debug/bitriseBuildId.txt");
+        final File debugBuildIdFile = new File(
+                functionalTestHelper.getTestDir(testName).getPath() + String.format(buildIdFileRelativePathFormat,
+                        "debug"));
 
         assertThat(debugBuildIdFile.exists(), is(true));
     }

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -2,7 +2,8 @@ package io.bitrise.trace.plugin.util;
 
 import androidx.annotation.NonNull;
 
-import org.apache.log4j.Logger;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.junit.rules.TestName;
 
 import java.io.File;
@@ -10,6 +11,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import io.bitrise.trace.plugin.TraceConstants;
 
@@ -24,20 +27,107 @@ public class FunctionalTestHelper {
      */
     private static final File testProjectDir =
             new File(System.getProperty("user.home") + "/BitriseTrace-TestGradleProject");
+
     @NonNull
     private final Logger logger;
 
     public FunctionalTestHelper() {
-        this.logger = Logger.getRootLogger();
+        this.logger = Logging.getLogger(this.getClass().getName());
     }
 
     /**
      * Publishes the trace-gradle-plugin itself and logs it.
      */
     public void publishTraceGradlePlugin() {
-        logger.info("Publishing plugin, to make sure it is up-to-date");
+        logger.lifecycle("Publishing plugin, to make sure it is up-to-date");
         FunctionalTestUtils.publishTraceGradlePlugin();
-        logger.info("Publishing plugin finished");
+        logger.lifecycle("Publishing plugin finished");
+    }
+
+    /**
+     * Prints the name of the test in a pretty ASCII text box.
+     *
+     * @param testName the name of the test to print.
+     */
+    public void logTestName(@NonNull final TestName testName) {
+        final String testNameString = testName.getMethodName();
+        final int testNameLength = testNameString.length();
+        final int paddingLength = 30;
+        final int lineLength = paddingLength + testNameLength;
+
+        final StringBuilder stringBuilder = new StringBuilder();
+
+        stringBuilder.append("\n");
+        stringBuilder.append(getTestNameBorderLogLine(lineLength));
+        stringBuilder.append(getTestNameEmptyLogLine(lineLength));
+        stringBuilder.append(getTestNameLogLine(testNameString, paddingLength));
+        stringBuilder.append(getTestNameEmptyLogLine(lineLength));
+        stringBuilder.append(getTestNameBorderLogLine(lineLength));
+
+        logger.lifecycle(stringBuilder.toString());
+    }
+
+    /**
+     * Prints the top or bottom line. Contains separators only.
+     *
+     * @param lineLength the length of the lines.
+     * @return the line.
+     */
+    @NonNull
+    private String getTestNameBorderLogLine(final int lineLength) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("+");
+        stringBuilder.append(concatWord("=", lineLength));
+        stringBuilder.append("+");
+        stringBuilder.append("\n");
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Prints a line with empty content.
+     *
+     * @param lineLength the length of the lines.
+     * @return the line.
+     */
+    @NonNull
+    private String getTestNameEmptyLogLine(final int lineLength) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("|");
+        stringBuilder.append(concatWord(" ", lineLength));
+        stringBuilder.append("|");
+        stringBuilder.append("\n");
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Prints the line with the name of the test.
+     *
+     * @param testName      the given text to display.
+     * @param paddingLength the length of padding for the line, excluding starting and ending cahars.
+     * @return the line.
+     */
+    @NonNull
+    private String getTestNameLogLine(final String testName, final int paddingLength) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("|");
+        stringBuilder.append(concatWord(" ", paddingLength / 2));
+        stringBuilder.append(testName);
+        stringBuilder.append(concatWord(" ", paddingLength / 2));
+        stringBuilder.append("|");
+        stringBuilder.append("\n");
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Concats the given word the given amount of times.
+     *
+     * @param word  the word to concat.
+     * @param times the number of times it should be concatenated.
+     * @return the concatenated String.
+     */
+    @NonNull
+    private String concatWord(@NonNull final String word, final int times) {
+        return IntStream.range(0, times).mapToObj(i -> word).collect(Collectors.joining(""));
     }
 
     /**

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -280,19 +280,4 @@ public class FunctionalTestHelper {
         }
 
     }
-
-    /**
-     * Sets up the local properties file by copying the given file to the given test. Consumes any I/O error if occurs.
-     *
-     * @param testName the name of the given test.
-     */
-    public void setupLocalProperties(@NonNull final TestName testName) {
-        final String testDirPath = getTestDirName(testName);
-
-        try {
-            FunctionalTestUtils.setUpAndroidSdkDirectory(testDirPath);
-        } catch (final IOException ioe) {
-            ioe.printStackTrace();
-        }
-    }
 }

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -45,26 +45,34 @@ public class FunctionalTestHelper {
     }
 
     /**
-     * Prints the name of the test in a pretty ASCII text box.
+     * Prints multiple lines with the given text in a pretty ASCII text box.
      *
-     * @param testName the name of the test to print.
+     * @param text the text to print.
      */
-    public void logTestName(@NonNull final TestName testName) {
-        final String testNameString = testName.getMethodName();
-        final int testNameLength = testNameString.length();
+    public void logInAsciiBox(@NonNull final String text) {
+        final int textLength = text.length();
         final int paddingLength = 30;
-        final int lineLength = paddingLength + testNameLength;
+        final int lineLength = paddingLength + textLength;
 
         final StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append("\n");
         stringBuilder.append(getTestNameBorderLogLine(lineLength));
         stringBuilder.append(getTestNameEmptyLogLine(lineLength));
-        stringBuilder.append(getTestNameLogLine(testNameString, paddingLength));
+        stringBuilder.append(getTestNameLogLine(text, paddingLength));
         stringBuilder.append(getTestNameEmptyLogLine(lineLength));
         stringBuilder.append(getTestNameBorderLogLine(lineLength));
 
         logger.lifecycle(stringBuilder.toString());
+    }
+
+    /**
+     * Prints multiple lines with the name of the test in a pretty ASCII text box.
+     *
+     * @param testName the name of the test to print.
+     */
+    public void logTestNameInAsciiBox(@NonNull final TestName testName) {
+        logInAsciiBox(testName.getMethodName());
     }
 
     /**

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -85,7 +85,7 @@ public class FunctionalTestHelper {
     private String getTestNameBorderLogLine(final int lineLength) {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("+");
-        stringBuilder.append(concatWord("=", lineLength));
+        stringBuilder.append(concatString("=", lineLength));
         stringBuilder.append("+");
         stringBuilder.append("\n");
         return stringBuilder.toString();
@@ -101,7 +101,7 @@ public class FunctionalTestHelper {
     private String getTestNameEmptyLogLine(final int lineLength) {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("|");
-        stringBuilder.append(concatWord(" ", lineLength));
+        stringBuilder.append(concatString(" ", lineLength));
         stringBuilder.append("|");
         stringBuilder.append("\n");
         return stringBuilder.toString();
@@ -118,24 +118,24 @@ public class FunctionalTestHelper {
     private String getTestNameLogLine(final String testName, final int paddingLength) {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("|");
-        stringBuilder.append(concatWord(" ", paddingLength / 2));
+        stringBuilder.append(concatString(" ", paddingLength / 2));
         stringBuilder.append(testName);
-        stringBuilder.append(concatWord(" ", paddingLength / 2));
+        stringBuilder.append(concatString(" ", paddingLength / 2));
         stringBuilder.append("|");
         stringBuilder.append("\n");
         return stringBuilder.toString();
     }
 
     /**
-     * Concats the given word the given amount of times.
+     * Concatenates the given String the given amount of times.
      *
-     * @param word  the word to concat.
-     * @param times the number of times it should be concatenated.
+     * @param string the String to concat.
+     * @param times  the number of times it should be concatenated.
      * @return the concatenated String.
      */
     @NonNull
-    private String concatWord(@NonNull final String word, final int times) {
-        return IntStream.range(0, times).mapToObj(i -> word).collect(Collectors.joining(""));
+    private String concatString(@NonNull final String string, final int times) {
+        return IntStream.range(0, times).mapToObj(i -> string).collect(Collectors.joining(""));
     }
 
     /**
@@ -165,7 +165,7 @@ public class FunctionalTestHelper {
      *
      * @param testName the name of the test.
      */
-    public void deleteTemporaryProject(@NonNull final TestName testName) {
+    public void deleteTestProjectDir(@NonNull final TestName testName) {
         final File testDir = getTestDir(testName);
         try {
             if (testDir.exists()) {
@@ -188,7 +188,7 @@ public class FunctionalTestHelper {
      */
     public void setupTestDir(@NonNull final TestName testName) {
         final String testDirPath = getTestDirName(testName);
-        deleteTemporaryProject(testName);
+        deleteTestProjectDir(testName);
         new File(testDirPath).mkdirs();
     }
 

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -111,7 +111,8 @@ public class FunctionalTestHelper {
      * Prints the line with the name of the test.
      *
      * @param testName      the given text to display.
-     * @param paddingLength the length of padding for the line, excluding starting and ending cahars.
+     * @param paddingLength the length of padding for the line, excluding starting and ending chars. Padding length
+     *                      should be an even number, otherwise it will result in uneven line lengths.
      * @return the line.
      */
     @NonNull

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -1,0 +1,200 @@
+package io.bitrise.trace.plugin.util;
+
+import androidx.annotation.NonNull;
+
+import org.apache.log4j.Logger;
+import org.junit.rules.TestName;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import io.bitrise.trace.plugin.TraceConstants;
+
+/**
+ * Helper class to support {@link io.bitrise.trace.plugin.TraceGradlePluginFunctionalTest}
+ */
+public class FunctionalTestHelper {
+
+    /**
+     * A temporary folder for running functional tests. A new gradle project will be setup in this folder, and the
+     * tests will run in this project.
+     */
+    private static final File testProjectDir =
+            new File(System.getProperty("user.home") + "/BitriseTrace-TestGradleProject");
+    @NonNull
+    private final Logger logger;
+
+    public FunctionalTestHelper() {
+        this.logger = Logger.getRootLogger();
+    }
+
+    /**
+     * Publishes the trace-gradle-plugin itself and logs it.
+     */
+    public void publishTraceGradlePlugin() {
+        logger.info("Publishing plugin, to make sure it is up-to-date");
+        FunctionalTestUtils.publishTraceGradlePlugin();
+        logger.info("Publishing plugin finished");
+    }
+
+    /**
+     * Gets the name of the current test's directory.
+     *
+     * @param testName the name of the test.
+     * @return the name of the test's directory.
+     */
+    @NonNull
+    public String getTestDirName(@NonNull final TestName testName) {
+        return testProjectDir.getAbsolutePath() + "/" + testName.getMethodName() + "/";
+    }
+
+    /**
+     * Gets the the current test's directory.
+     *
+     * @param testName the name of the test.
+     * @return the test's directory.
+     */
+    @NonNull
+    public File getTestDir(@NonNull final TestName testName) {
+        return new File(getTestDirName(testName));
+    }
+
+    /**
+     * Force-delete an existing folder and its contents, located at {@link #testProjectDir}
+     *
+     * @param testName the name of the test.
+     */
+    public void deleteTemporaryProject(@NonNull final TestName testName) {
+        final File testDir = getTestDir(testName);
+        try {
+            if (testDir.exists()) {
+                Path pathToBeDeleted = testDir.toPath();
+                Files.walk(pathToBeDeleted)
+                     .sorted(Comparator.reverseOrder())
+                     .map(Path::toFile)
+                     .forEach(File::delete);
+            }
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Sets up the test directory by deleting and creating it again.
+     *
+     * @param testName the name of the given test.
+     */
+    public void setupTestDir(@NonNull final TestName testName) {
+        final String testDirPath = getTestDirName(testName);
+        deleteTemporaryProject(testName);
+        new File(testDirPath).mkdirs();
+    }
+
+    /**
+     * Sets up the Trace properties by copying the given property files to the given test. Consumes any I/O error if
+     * occurs.
+     *
+     * @param testName the name of the given test.
+     */
+    public void setupTraceProperties(@NonNull final TestName testName) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.copyFile(TestConstants.GRADLE_PROPERTIES_FILE_NAME,
+                    testDirPath + "traceGradlePlugin.properties");
+            FunctionalTestUtils.copyFile("../trace-sdk/" + TestConstants.GRADLE_PROPERTIES_FILE_NAME,
+                    testDirPath + "traceSdk.properties");
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     * Sets up the Gradle properties by copying the given property file to the given test. Consumes any I/O error if
+     * occurs.
+     *
+     * @param testName the name of the given test.
+     * @param index    the prefix index of the property file.
+     */
+    public void setupGradleProperties(@NonNull final TestName testName, final int index) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.copyFile(FunctionalTestUtils.getGradlePropertiesForResource(index),
+                    testDirPath + TestConstants.GRADLE_PROPERTIES_FILE_NAME);
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     * Sets up the Gradle build file by copying the given file to the given test. Consumes any I/O error if occurs.
+     *
+     * @param testName the name of the given test.
+     * @param index    the prefix index of the build file.
+     */
+    public void setupBuildGradle(@NonNull final TestName testName, final int index) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.copyFile(FunctionalTestUtils.getBuildGradleForResource(index),
+                    testDirPath + TestConstants.BUILD_GRADLE_FILE_NAME);
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     * Sets up the Bitrise addons file by copying the given file to the given test. Consumes any I/O error if occurs.
+     *
+     * @param testName the name of the given test.
+     * @param index    the prefix index of the addons file.
+     */
+    public void setupBitriseAddons(@NonNull final TestName testName, final int index) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.copyFile(FunctionalTestUtils.getBitriseAddonsConfigForResource(index),
+                    testDirPath + TraceConstants.BITRISE_ADDONS_CONFIGURATION_FILE);
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     * Sets up the Android manifest file by copying the given file to the given test. Consumes any I/O error if occurs.
+     *
+     * @param testName the name of the given test.
+     * @param index    the prefix index of the manifest file.
+     */
+    public void setupAndroidManifest(@NonNull final TestName testName, final int index) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.copyFile(FunctionalTestUtils.getAndroidManifestForResource(index),
+                    FunctionalTestUtils.getAndroidManifestDefaultPath(testDirPath));
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+
+    }
+
+    /**
+     * Sets up the local properties file by copying the given file to the given test. Consumes any I/O error if occurs.
+     *
+     * @param testName the name of the given test.
+     */
+    public void setupLocalProperties(@NonNull final TestName testName) {
+        final String testDirPath = getTestDirName(testName);
+
+        try {
+            FunctionalTestUtils.setUpAndroidSdkDirectory(testDirPath);
+        } catch (final IOException ioe) {
+            ioe.printStackTrace();
+        }
+    }
+}

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestUtils.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestUtils.java
@@ -100,44 +100,6 @@ public class FunctionalTestUtils {
     }
 
     /**
-     * Gets the path of the working directory.
-     *
-     * @return the working directory path.
-     * @see <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">System Properties</a>
-     */
-    @NonNull
-    public static String getWorkingDirectoryPath() {
-        return new File(System.getProperty("user.dir")).getParentFile().toString() + "/";
-    }
-
-    /**
-     * Sets up your SDK directory location by copying the local.properties auto-generated file (if available) to the
-     * test directory. Tests might fail if the SDK directory is not set. To set the SDK directory one of the
-     * following should be true:
-     * <ul>
-     * <li>Must have copy the local.properties to the given folder</li>
-     * <li>Environment variables {@code $ANDROID_HOME} and {@code $ANDROID_SDK_ROOT} are
-     * set:</li>
-     * <ul>
-     * <li>Globally, see documentation</li>
-     * <li>In the 'Run Configuration' of the given build in Android Studio</li>
-     * </ul>
-     * </ul>
-     *
-     * @param dirPath the destination directory for the copy of the local.properties file.
-     * @throws IOException if an I/O error occurs.
-     * @see
-     * <a href="https://developer.android.com/studio/command-line/variables">Defining global environment variables</a>
-     */
-    public static void setUpAndroidSdkDirectory(@NonNull final String dirPath)
-            throws IOException {
-        final String workingDirectoryPath = FunctionalTestUtils.getWorkingDirectoryPath();
-
-        FunctionalTestUtils.copyFile(workingDirectoryPath + TestConstants.LOCAL_DOT_PROPERTIES,
-                dirPath + TestConstants.LOCAL_DOT_PROPERTIES);
-    }
-
-    /**
      * Publishes the 'trace-gradle-plugin' with it's current state, to make sure tests are run on the up-to-date
      * version.
      */

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -1,0 +1,130 @@
+package io.bitrise.trace.plugin.util;
+
+import androidx.annotation.NonNull;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+/**
+ * Custom implementation of the {@link PrintWriter} class, to add different coloring to the output and some extra
+ * indentation.
+ */
+public class FunctionalTestWriter extends PrintWriter {
+
+    private static final char[] indentation = new char[]{' ', ' ', ' '};
+    private static final char[] escapeChar = new char[]{27};
+    private final char[] coloringCode;
+    private final int extraLength;
+
+    /**
+     * Constructor for class, Requires the given OutputStream and the {@link PrintColor} which will be used.
+     *
+     * @param outputStream the OutputStream.
+     * @param printColor   the given color.
+     */
+    public FunctionalTestWriter(@NonNull final OutputStream outputStream, @NonNull final PrintColor printColor) {
+        super(outputStream);
+        this.coloringCode = createColorCode(printColor);
+        this.extraLength = indentation.length + coloringCode.length + escapeChar.length;
+    }
+
+    /**
+     * Inserts to the start the escape char.
+     *
+     * @param chars the given chars to escape.
+     * @return the given chars with the escape char.
+     */
+    @NonNull
+    private static char[] concatEscapeChar(@NonNull final char[] chars) {
+        return concatCharArrays(escapeChar, chars);
+    }
+
+    /**
+     * Concatenates two arrays of chars.
+     *
+     * @param first  the first array.
+     * @param second the second array.
+     * @return the concatenated result.
+     */
+    @NonNull
+    private static char[] concatCharArrays(@NonNull final char[] first, @NonNull final char[] second) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(first);
+        stringBuilder.append(second);
+        return stringBuilder.toString().toCharArray();
+    }
+
+    /**
+     * Creates a color code from the given {@link PrintColor}.
+     *
+     * @param printColor the given PrintColor.
+     * @return the char array representation of the given color.
+     */
+    @NonNull
+    private static char[] createColorCode(@NonNull final PrintColor printColor) {
+        return ("[" + printColor.getColorCode() + "m").toCharArray();
+    }
+
+    /**
+     * Resets the console to the default color.
+     */
+    public static void reset() {
+        System.out.println(concatEscapeChar(createColorCode(PrintColor.DEFAULT)));
+    }
+
+    @Override
+    public void write(@NonNull final char[] chars, final int i, final int i1) {
+        final char[] coloredChars = color(chars);
+        final char[] output = addIndent(coloredChars);
+        super.write(output, i, i1 + extraLength);
+    }
+
+    /**
+     * Inserts to the start of the given char array the {@link #indentation}.
+     *
+     * @param chars the given chars.
+     * @return the indented array of chars.
+     */
+    @NonNull
+    private char[] addIndent(@NonNull final char[] chars) {
+        return concatCharArrays(indentation, chars);
+    }
+
+    /**
+     * Inserts to the start the coloring chars to a given array of chars.
+     *
+     * @param chars the given array of chars.
+     * @return the given text with the coloring chars.
+     */
+    @NonNull
+    private char[] color(@NonNull final char[] chars) {
+        final char[] escaped = concatEscapeChar(coloringCode);
+        return concatCharArrays(escaped, chars);
+    }
+
+    /**
+     * Enum class for different colors. This is based on the ANSI escape codes-
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
+     */
+    public enum PrintColor {
+        RED(31),
+        GREEN(32),
+        YELLOW(33),
+        BLUE(34),
+        MAGENTA(35),
+        CYAN(36),
+        WHITE(36),
+        DEFAULT(39);
+
+        private final int colorCode;
+
+        PrintColor(final int colorCode) {
+            this.colorCode = colorCode;
+        }
+
+        public int getColorCode() {
+            return colorCode;
+        }
+    }
+}

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -103,7 +103,7 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Enum class for different colors. This is based on the ANSI escape codes-
+     * Enum class for different colors. This is based on the ANSI escape codes.
      *
      * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
      */

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -7,7 +7,10 @@ import java.io.PrintWriter;
 
 /**
  * Custom implementation of the {@link PrintWriter} class, to add different coloring to the output and some extra
- * indentation.
+ * indentation. Please note that adding the coloring will stay until changed. To reset it to the default please use
+ * the {@link #reset()} method. The coloring is based on the ANSI escape codes.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
  */
 public class FunctionalTestWriter extends PrintWriter {
 
@@ -62,14 +65,25 @@ public class FunctionalTestWriter extends PrintWriter {
      */
     @NonNull
     private static char[] createColorCode(@NonNull final PrintColor printColor) {
-        return ("[" + printColor.getColorCode() + "m").toCharArray();
+        final Rgb rgb = printColor.getRgb();
+        return String.format("[38;2;%s;%s;%sm", rgb.getRed(), rgb.getGreen(), rgb.getBlue()).toCharArray();
+    }
+
+    /**
+     * Gets the default console printing color.
+     *
+     * @return the char array representation of the default color.
+     */
+    @NonNull
+    private static char[] getDefaultColorCode() {
+        return ("[39m").toCharArray();
     }
 
     /**
      * Resets the console to the default color.
      */
     public static void reset() {
-        System.out.println(concatEscapeChar(createColorCode(PrintColor.DEFAULT)));
+        System.out.println(concatEscapeChar(getDefaultColorCode()));
     }
 
     @Override
@@ -91,7 +105,8 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Inserts to the start the coloring chars to a given array of chars.
+     * Inserts to the start the coloring chars to a given array of chars. Please note that adding the coloring will
+     * stay until changed. To reset it to the default please use the {@link #reset()} method.
      *
      * @param chars the given array of chars.
      * @return the given text with the coloring chars.
@@ -103,28 +118,52 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Enum class for different colors. This is based on the ANSI escape codes.
+     * Enum class for different colors. The color RGB values are in align with the Bitkit.
      *
-     * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
+     * @see
+     * <a href="https://bitkit.netlify.app/documentation/materials/colors">https://bitkit.netlify.app/documentation/materials/colors</a>
      */
     public enum PrintColor {
-        RED(31),
-        GREEN(32),
-        YELLOW(33),
-        BLUE(34),
-        MAGENTA(35),
-        CYAN(36),
-        WHITE(36),
-        DEFAULT(39);
+        RED4(new Rgb(238, 0, 59)),
+        AQUA4(new Rgb(14, 199, 186));
 
-        private final int colorCode;
+        private final Rgb rgb;
 
-        PrintColor(final int colorCode) {
-            this.colorCode = colorCode;
+        PrintColor(@NonNull final Rgb rgb) {
+            this.rgb = rgb;
         }
 
-        public int getColorCode() {
-            return colorCode;
+        public Rgb getRgb() {
+            return rgb;
         }
+    }
+
+    /**
+     * Data class for representing a RGB color.
+     */
+    public static class Rgb {
+
+        private final int red;
+        private final int green;
+        private final int blue;
+
+        public Rgb(final int red, final int green, final int blue) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+        }
+
+        public int getRed() {
+            return red;
+        }
+
+        public int getGreen() {
+            return green;
+        }
+
+        public int getBlue() {
+            return blue;
+        }
+
     }
 }


### PR DESCRIPTION
Created FunctionalTestHelper and moved some supportive function there.
Added divider text boxes between the functional tests of
trace-gradle-plugin to help readability.

APM-2920