### PR TITLE
chore: Log cleaning for functional tests

### DIFF
--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -87,7 +87,6 @@ public class TraceGradlePluginFunctionalTest {
     public void setUpTest() {
         functionalTestHelper.logTestNameInAsciiBox(testName);
         functionalTestHelper.setupTestDir(testName);
-        functionalTestHelper.setupLocalProperties(testName);
         functionalTestHelper.setupTraceProperties(testName);
         functionalTestHelper.setupGradleProperties(testName, 0);
         functionalTestHelper.setupBitriseAddons(testName, 0);

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/TraceGradlePluginFunctionalTest.java
@@ -69,17 +69,17 @@ public class TraceGradlePluginFunctionalTest {
 
     /**
      * An instance of {@link FunctionalTestWriter} that will write the output of each test case to the console with
-     * cyan color.
+     * AQUA4 color from the Bitkit.
      */
     private final FunctionalTestWriter stdOutWriter = new FunctionalTestWriter(System.out,
-            FunctionalTestWriter.PrintColor.CYAN);
+            FunctionalTestWriter.PrintColor.AQUA4);
 
     /**
      * An instance of {@link FunctionalTestWriter} that will write the error of each test case to the console with
-     * magenta color.
+     * RED4 color from the Bitkit.
      */
     private final FunctionalTestWriter errWriter = new FunctionalTestWriter(System.err,
-            FunctionalTestWriter.PrintColor.MAGENTA);
+            FunctionalTestWriter.PrintColor.RED4);
 
     /**
      * Sets up the test class.

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestHelper.java
@@ -280,19 +280,4 @@ public class FunctionalTestHelper {
         }
 
     }
-
-    /**
-     * Sets up the local properties file by copying the given file to the given test. Consumes any I/O error if occurs.
-     *
-     * @param testName the name of the given test.
-     */
-    public void setupLocalProperties(@NonNull final TestName testName) {
-        final String testDirPath = getTestDirName(testName);
-
-        try {
-            FunctionalTestUtils.setUpAndroidSdkDirectory(testDirPath);
-        } catch (final IOException ioe) {
-            ioe.printStackTrace();
-        }
-    }
 }

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestUtils.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestUtils.java
@@ -100,44 +100,6 @@ public class FunctionalTestUtils {
     }
 
     /**
-     * Gets the path of the working directory.
-     *
-     * @return the working directory path.
-     * @see <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">System Properties</a>
-     */
-    @NonNull
-    public static String getWorkingDirectoryPath() {
-        return new File(System.getProperty("user.dir")).getParentFile().toString() + "/";
-    }
-
-    /**
-     * Sets up your SDK directory location by copying the local.properties auto-generated file (if available) to the
-     * test directory. Tests might fail if the SDK directory is not set. To set the SDK directory one of the
-     * following should be true:
-     * <ul>
-     * <li>Must have copy the local.properties to the given folder</li>
-     * <li>Environment variables {@code $ANDROID_HOME} and {@code $ANDROID_SDK_ROOT} are
-     * set:</li>
-     * <ul>
-     * <li>Globally, see documentation</li>
-     * <li>In the 'Run Configuration' of the given build in Android Studio</li>
-     * </ul>
-     * </ul>
-     *
-     * @param dirPath the destination directory for the copy of the local.properties file.
-     * @throws IOException if an I/O error occurs.
-     * @see
-     * <a href="https://developer.android.com/studio/command-line/variables">Defining global environment variables</a>
-     */
-    public static void setUpAndroidSdkDirectory(@NonNull final String dirPath)
-            throws IOException {
-        final String workingDirectoryPath = FunctionalTestUtils.getWorkingDirectoryPath();
-
-        FunctionalTestUtils.copyFile(workingDirectoryPath + TestConstants.LOCAL_DOT_PROPERTIES,
-                dirPath + TestConstants.LOCAL_DOT_PROPERTIES);
-    }
-
-    /**
      * Publishes the 'trace-gradle-plugin' with it's current state, to make sure tests are run on the up-to-date
      * version.
      */

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -1,0 +1,130 @@
+package io.bitrise.trace.plugin.util;
+
+import androidx.annotation.NonNull;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+/**
+ * Custom implementation of the {@link PrintWriter} class, to add different coloring to the output and some extra
+ * indentation.
+ */
+public class FunctionalTestWriter extends PrintWriter {
+
+    private static final char[] indentation = new char[]{' ', ' ', ' '};
+    private static final char[] escapeChar = new char[]{27};
+    private final char[] coloringCode;
+    private final int extraLength;
+
+    /**
+     * Constructor for class, Requires the given OutputStream and the {@link PrintColor} which will be used.
+     *
+     * @param outputStream the OutputStream.
+     * @param printColor   the given color.
+     */
+    public FunctionalTestWriter(@NonNull final OutputStream outputStream, @NonNull final PrintColor printColor) {
+        super(outputStream);
+        this.coloringCode = createColorCode(printColor);
+        this.extraLength = indentation.length + coloringCode.length + escapeChar.length;
+    }
+
+    /**
+     * Inserts to the start the escape char.
+     *
+     * @param chars the given chars to escape.
+     * @return the given chars with the escape char.
+     */
+    @NonNull
+    private static char[] concatEscapeChar(@NonNull final char[] chars) {
+        return concatCharArrays(escapeChar, chars);
+    }
+
+    /**
+     * Concatenates two arrays of chars.
+     *
+     * @param first  the first array.
+     * @param second the second array.
+     * @return the concatenated result.
+     */
+    @NonNull
+    private static char[] concatCharArrays(@NonNull final char[] first, @NonNull final char[] second) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(first);
+        stringBuilder.append(second);
+        return stringBuilder.toString().toCharArray();
+    }
+
+    /**
+     * Creates a color code from the given {@link PrintColor}.
+     *
+     * @param printColor the given PrintColor.
+     * @return the char array representation of the given color.
+     */
+    @NonNull
+    private static char[] createColorCode(@NonNull final PrintColor printColor) {
+        return ("[" + printColor.getColorCode() + "m").toCharArray();
+    }
+
+    /**
+     * Resets the console to the default color.
+     */
+    public static void reset() {
+        System.out.println(concatEscapeChar(createColorCode(PrintColor.DEFAULT)));
+    }
+
+    @Override
+    public void write(@NonNull final char[] chars, final int i, final int i1) {
+        final char[] coloredChars = color(chars);
+        final char[] output = addIndent(coloredChars);
+        super.write(output, i, i1 + extraLength);
+    }
+
+    /**
+     * Inserts to the start of the given char array the {@link #indentation}.
+     *
+     * @param chars the given chars.
+     * @return the indented array of chars.
+     */
+    @NonNull
+    private char[] addIndent(@NonNull final char[] chars) {
+        return concatCharArrays(indentation, chars);
+    }
+
+    /**
+     * Inserts to the start the coloring chars to a given array of chars.
+     *
+     * @param chars the given array of chars.
+     * @return the given text with the coloring chars.
+     */
+    @NonNull
+    private char[] color(@NonNull final char[] chars) {
+        final char[] escaped = concatEscapeChar(coloringCode);
+        return concatCharArrays(escaped, chars);
+    }
+
+    /**
+     * Enum class for different colors. This is based on the ANSI escape codes-
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
+     */
+    public enum PrintColor {
+        RED(31),
+        GREEN(32),
+        YELLOW(33),
+        BLUE(34),
+        MAGENTA(35),
+        CYAN(36),
+        WHITE(36),
+        DEFAULT(39);
+
+        private final int colorCode;
+
+        PrintColor(final int colorCode) {
+            this.colorCode = colorCode;
+        }
+
+        public int getColorCode() {
+            return colorCode;
+        }
+    }
+}

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -103,7 +103,7 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Enum class for different colors. This is based on the ANSI escape codes-
+     * Enum class for different colors. This is based on the ANSI escape codes.
      *
      * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
      */

--- a/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
+++ b/trace-gradle-plugin/src/functionalTest/java/io/bitrise/trace/plugin/util/FunctionalTestWriter.java
@@ -7,7 +7,10 @@ import java.io.PrintWriter;
 
 /**
  * Custom implementation of the {@link PrintWriter} class, to add different coloring to the output and some extra
- * indentation.
+ * indentation. Please note that adding the coloring will stay until changed. To reset it to the default please use
+ * the {@link #reset()} method. The coloring is based on the ANSI escape codes.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
  */
 public class FunctionalTestWriter extends PrintWriter {
 
@@ -62,14 +65,25 @@ public class FunctionalTestWriter extends PrintWriter {
      */
     @NonNull
     private static char[] createColorCode(@NonNull final PrintColor printColor) {
-        return ("[" + printColor.getColorCode() + "m").toCharArray();
+        final Rgb rgb = printColor.getRgb();
+        return String.format("[38;2;%s;%s;%sm", rgb.getRed(), rgb.getGreen(), rgb.getBlue()).toCharArray();
+    }
+
+    /**
+     * Gets the default console printing color.
+     *
+     * @return the char array representation of the default color.
+     */
+    @NonNull
+    private static char[] getDefaultColorCode() {
+        return ("[39m").toCharArray();
     }
 
     /**
      * Resets the console to the default color.
      */
     public static void reset() {
-        System.out.println(concatEscapeChar(createColorCode(PrintColor.DEFAULT)));
+        System.out.println(concatEscapeChar(getDefaultColorCode()));
     }
 
     @Override
@@ -91,7 +105,8 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Inserts to the start the coloring chars to a given array of chars.
+     * Inserts to the start the coloring chars to a given array of chars. Please note that adding the coloring will
+     * stay until changed. To reset it to the default please use the {@link #reset()} method.
      *
      * @param chars the given array of chars.
      * @return the given text with the coloring chars.
@@ -103,28 +118,52 @@ public class FunctionalTestWriter extends PrintWriter {
     }
 
     /**
-     * Enum class for different colors. This is based on the ANSI escape codes.
+     * Enum class for different colors. The color RGB values are in align with the Bitkit.
      *
-     * @see <a href="https://en.wikipedia.org/wiki/ANSI_escape_code">https://en.wikipedia.org/wiki/ANSI_escape_code</a>
+     * @see
+     * <a href="https://bitkit.netlify.app/documentation/materials/colors">https://bitkit.netlify.app/documentation/materials/colors</a>
      */
     public enum PrintColor {
-        RED(31),
-        GREEN(32),
-        YELLOW(33),
-        BLUE(34),
-        MAGENTA(35),
-        CYAN(36),
-        WHITE(36),
-        DEFAULT(39);
+        RED4(new Rgb(238, 0, 59)),
+        AQUA4(new Rgb(14, 199, 186));
 
-        private final int colorCode;
+        private final Rgb rgb;
 
-        PrintColor(final int colorCode) {
-            this.colorCode = colorCode;
+        PrintColor(@NonNull final Rgb rgb) {
+            this.rgb = rgb;
         }
 
-        public int getColorCode() {
-            return colorCode;
+        public Rgb getRgb() {
+            return rgb;
         }
+    }
+
+    /**
+     * Data class for representing a RGB color.
+     */
+    public static class Rgb {
+
+        private final int red;
+        private final int green;
+        private final int blue;
+
+        public Rgb(final int red, final int green, final int blue) {
+            this.red = red;
+            this.green = green;
+            this.blue = blue;
+        }
+
+        public int getRed() {
+            return red;
+        }
+
+        public int getGreen() {
+            return green;
+        }
+
+        public int getBlue() {
+            return blue;
+        }
+
     }
 }


### PR DESCRIPTION
local.properties files are not copied anymore, as they are not required
for the functional tests.

APM-2921