### PR TITLE
tests: Increase coverage for core data

### DIFF
--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
@@ -1,0 +1,39 @@
+package io.bitrise.trace;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import androidx.test.platform.app.InstrumentationRegistry;
+import io.bitrise.trace.configuration.ConfigurationManager;
+import io.bitrise.trace.utils.log.TraceLog;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Instrumented tests for {@link TraceSdk}.
+ */
+public class TraceSdkInstrumentedTest {
+
+  final Context context = InstrumentationRegistry.getInstrumentation()
+                                                 .getTargetContext()
+                                                 .getApplicationContext();
+
+  @Before
+  public void before() {
+    TraceSdk.reset();
+  }
+
+  @Test
+  public void initConfigurations() {
+    TraceSdk.initConfigurations(context);
+    assertTrue(ConfigurationManager.isInitialised());
+  }
+
+  @Test
+  public void initNetworkTracing() {
+    TraceSdk.initNetworkTracing();
+    assertTrue(TraceSdk.isNetworkTracingEnabled);
+  }
+}

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
@@ -7,15 +7,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.os.AsyncTask;
 import androidx.test.annotation.UiThreadTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import io.bitrise.trace.configuration.ConfigurationManager;
-import io.bitrise.trace.data.collector.DataCollector;
-import io.bitrise.trace.data.collector.DataListener;
 import io.bitrise.trace.data.collector.DataSourceType;
 import io.bitrise.trace.data.collector.DummyDataCollector;
 import io.bitrise.trace.data.collector.DummyDataListener;
@@ -24,10 +21,6 @@ import io.bitrise.trace.data.storage.DataStorage;
 import io.bitrise.trace.data.storage.TestDataStorage;
 import io.bitrise.trace.scheduler.ServiceScheduler;
 import io.bitrise.trace.session.ApplicationSessionManager;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,17 +47,6 @@ public class DataManagerInstrumentedTest {
                                      .getTargetContext()
                                      .getApplicationContext();
     mockConfigurationManager = mock(ConfigurationManager.class);
-    final Set<DataCollector> dummyDataCollectors =
-        new HashSet<>(Arrays.asList(
-            new DummyDataCollector("dummyCollector1"),
-            new DummyDataCollector("dummyCollector2")));
-    when(mockConfigurationManager.getDataCollectors(context)).thenReturn(dummyDataCollectors);
-    final LinkedHashSet<DataListener> dummyDataListeners = new LinkedHashSet<>(
-        Arrays.asList(
-            new DummyDataListener("dummyListener1"),
-            new DummyDataListener("dummyListener2"),
-            new DummyDataListener("dummyListener3")));
-    when(mockConfigurationManager.getDataListeners(context)).thenReturn(dummyDataListeners);
   }
 
   /**
@@ -83,80 +65,24 @@ public class DataManagerInstrumentedTest {
   }
 
   /**
-   * When the sending is stopped with {@link DataManager#stopSending(android.content.Context)} the
+   * When the sending is stopped with {@link DataManager#stopSending()} the
    * {@link ServiceScheduler#cancelAll()} should be called.
    */
   @Test
   public void stopSending_shouldCallCancelAll() {
-    dataManager.stopSending(context);
+    dataManager.stopSending();
 
     verify(dataManager.metricServiceScheduler, times(1)).cancelAll();
     verify(dataManager.traceServiceScheduler, times(1)).cancelAll();
   }
 
   /**
-   * Test when the Data collection in started in the DataManager, the number of active
-   * DataCollectors should be 2 based on {@link #setUp()}.
-   */
-  @Test
-  public void startCollection_shouldActiveCollectorsBeNotEmptyAfterStart() {
-    dataManager.startCollection(context);
-
-    final int expectedValue = 2;
-    final int actualValue = dataManager.getActiveDataCollectors().size();
-
-    assertThat(actualValue, is(expectedValue));
-  }
-
-  /**
-   * Test when the Data collection in stopped in the DataManager, the number of active
-   * DataCollectors should be zero.
-   */
-  @Test
-  public void stopCollection_shouldHaveZeroActiveCollectors_AfterStop() {
-    dataManager.stopCollection();
-
-    final int expectedValue = 0;
-    final int actualValue = dataManager.getActiveDataCollectors().size();
-
-    assertThat(actualValue, is(expectedValue));
-  }
-
-  /**
-   * Test when the Data collection in started in the DataManager, the number of active
-   * DataListeners should be 3 based on {@link #setUp()}.
-   */
-  @Test
-  public void startCollection_shouldActiveListenersBeNotEmptyAfterStart() {
-    dataManager.startCollection(context);
-
-    final int expectedValue = 3;
-    final int actualValue = dataManager.getActiveDataListeners().size();
-
-    assertThat(actualValue, is(expectedValue));
-  }
-
-  /**
-   * Test when the Data collection in stopped in the DataManager, the number of active
-   * DataListeners should be zero.
-   */
-  @Test
-  public void stopCollection_shouldHaveZeroActiveListeners_AfterStop() {
-    dataManager.stopCollection();
-
-    final int expectedValue = 0;
-    final int actualValue = dataManager.getActiveDataListeners().size();
-
-    assertThat(actualValue, is(expectedValue));
-  }
-
-  /**
-   * When the sending is started the {@link DataManager#stopSending(Context)} should be called.
+   * When the sending is started the {@link DataManager#stopSending()} should be called.
    */
   @Test
   public void startSending_shouldCallStop() {
     mockDataManager.startSending(context);
-    verify(mockDataManager, times(1)).stopSending(context);
+    verify(mockDataManager, times(1)).stopSending();
   }
 
   /**
@@ -178,29 +104,6 @@ public class DataManagerInstrumentedTest {
     final DataManager expectedValue = DataManager.getInstance(context);
     final DataManager actualValue = DataManager.getInstance(context);
     assertThat(actualValue, sameInstance(expectedValue));
-  }
-
-  /**
-   * Checks that a call to {@link DataManager#isInitialised()} should return {@code true} after
-   * a call made to {@link DataManager#getInstance(Context)}.
-   */
-  @Test
-  public void getInstance_shouldInitialise() {
-    DataManager.getInstance(context);
-    final boolean actualValue = DataManager.isInitialised();
-    assertThat(actualValue, is(true));
-  }
-
-  /**
-   * Checks that a call to {@link DataManager#isInitialised()} should return {@code false} after
-   * a call made to {@link DataManager#reset()}.
-   */
-  @Test
-  public void reset_shouldNotBeInitialised() {
-    DataManager.getInstance(context);
-    DataManager.reset();
-    final boolean actualValue = DataManager.isInitialised();
-    assertThat(actualValue, is(false));
   }
 
   /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -32,8 +32,10 @@ public class TraceSdk {
    * The name for the product.
    */
   public static final String NAME = "Trace Android";
+
+  @VisibleForTesting
   @Nullable
-  private static volatile TraceSdk traceSdk;
+  static volatile TraceSdk traceSdk;
   /**
    * The TraceSdk has a debug mode - currently this will mean more debug level log messages.
    *
@@ -42,6 +44,9 @@ public class TraceSdk {
    * ensure that the TraceSdk has been initialised before setting the debug enabled mode.
    */
   private static boolean DEBUG_ENABLED = false;
+
+
+  static boolean isNetworkTracingEnabled = false;
 
   private TraceSdk() {
     // nop
@@ -104,7 +109,8 @@ public class TraceSdk {
    * Initialises the custom trace logger based on the current build type. Note: In future we
    * would like a way for this to be customisable by developers.
    */
-  private static void initLogger() {
+  @VisibleForTesting
+  static void initLogger() {
     if (ConfigurationManager.getInstance().isAppDebugBuild()) {
       TraceLog.makeAndroidLogger();
     } else {
@@ -198,10 +204,12 @@ public class TraceSdk {
    * Initialises the network tracing, currently initialising {@link java.net.URLConnection}
    * type network requests to use our {@link TraceURLStreamHandlerFactory} instead.
    */
-  private static void initNetworkTracing() {
+  @VisibleForTesting
+  static void initNetworkTracing() {
     try {
       URL.setURLStreamHandlerFactory(new TraceURLStreamHandlerFactory());
       TraceLog.d(LogMessageConstants.URL_CONNECTION_REQUESTS_SUCCESS);
+      isNetworkTracingEnabled = true;
     } catch (final Error e) {
       // this will catch the java.lang.Error: factory already defined error which should
       // only be caused from the integration tests calling init multiple times.

--- a/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
@@ -27,6 +27,8 @@ import io.bitrise.trace.data.collector.view.ApplicationForegroundStateDataListen
 import io.bitrise.trace.data.collector.view.ApplicationStartUpDataListener;
 import io.bitrise.trace.data.collector.view.FragmentStateDataListener;
 import io.bitrise.trace.data.resource.ResourceLabel;
+import io.bitrise.trace.utils.log.LogMessageConstants;
+import io.bitrise.trace.utils.log.TraceLog;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -112,8 +114,14 @@ public class ConfigurationManager {
     getInstance();
     initialised = true;
     configurationMap = new HashMap<>();
-    importConfigurationFromBuildConfig(context);
-    importConfigurationFromResValues(context);
+
+    try {
+      importConfigurationFromBuildConfig(context);
+      importConfigurationFromResValues(context);
+    } catch (Resources.NotFoundException exception) {
+      TraceLog.e(LogMessageConstants.CONFIGURATION_MANAGER_COULD_NOT_FIND_RESOURCES);
+    }
+
   }
 
   /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/session/ApplicationSessionManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/session/ApplicationSessionManager.java
@@ -2,6 +2,7 @@ package io.bitrise.trace.session;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.bitrise.trace.utils.log.LogMessageConstants;
 import io.bitrise.trace.utils.log.TraceLog;
 import javax.inject.Singleton;
@@ -75,5 +76,15 @@ public class ApplicationSessionManager implements SessionManager {
   @Override
   public Session getActiveSession() {
     return session;
+  }
+
+  @VisibleForTesting
+  static synchronized boolean isSessionManagerActive() {
+    return sessionManager != null;
+  }
+
+  @VisibleForTesting
+  static synchronized boolean isSessionActive() {
+    return session != null;
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
@@ -77,7 +77,7 @@ public final class LogMessageConstants {
       "UrlConnection listening has successfully been configured, all requests using UrlConnection"
           + " will be reported by the Trace SDK.";
 
-  public static final String CONFIGURATION_MANAGER_COULD_NOT_FIND_RESOURCES = "Trace could not " +
-      "find the required token. Please ensure you have followed the setup instructions.";
+  public static final String CONFIGURATION_MANAGER_COULD_NOT_FIND_RESOURCES = "Trace could not "
+      + "find the required token. Please ensure you have followed the setup instructions.";
 }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/LogMessageConstants.java
@@ -76,5 +76,8 @@ public final class LogMessageConstants {
   public static final String URL_CONNECTION_REQUESTS_SUCCESS =
       "UrlConnection listening has successfully been configured, all requests using UrlConnection"
           + " will be reported by the Trace SDK.";
+
+  public static final String CONFIGURATION_MANAGER_COULD_NOT_FIND_RESOURCES = "Trace could not " +
+      "find the required token. Please ensure you have followed the setup instructions.";
 }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/TraceLog.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/TraceLog.java
@@ -31,10 +31,6 @@ public class TraceLog {
    */
   public static synchronized Logger makeAndroidLogger() {
     synchronized (lock) {
-      if (logger != null) {
-        return logger;
-      }
-
       logger = new AndroidLogger();
       return logger;
     }
@@ -47,10 +43,6 @@ public class TraceLog {
    */
   public static synchronized Logger makeSilentLogger() {
     synchronized (lock) {
-      if (logger != null) {
-        return logger;
-      }
-
       logger = new SilentLogger();
       return logger;
     }
@@ -63,10 +55,6 @@ public class TraceLog {
    */
   public static synchronized Logger makeErrorOnlyLogger() {
     synchronized (lock) {
-      if (logger != null) {
-        return logger;
-      }
-
       logger = new ErrorOnlyLogger();
       return logger;
     }
@@ -92,7 +80,7 @@ public class TraceLog {
    * Resets the current logger - required only for testing purposes.
    */
   @VisibleForTesting
-  static synchronized void reset() {
+  public static synchronized void reset() {
     synchronized (lock) {
       logger = null;
     }

--- a/trace-sdk/src/test/java/io/bitrise/trace/TraceSdkTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/TraceSdkTest.java
@@ -3,23 +3,122 @@ package io.bitrise.trace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import android.app.Application;
+import android.content.Context;
+import io.bitrise.trace.configuration.ConfigurationManager;
+import io.bitrise.trace.data.management.DataManager;
 import io.bitrise.trace.session.ApplicationSessionManager;
 import io.bitrise.trace.session.Session;
+import io.bitrise.trace.utils.log.AndroidLogger;
+import io.bitrise.trace.utils.log.ErrorOnlyLogger;
+import io.bitrise.trace.utils.log.TraceLog;
+import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Test cases for {@link TraceSdk}.
  */
 public class TraceSdkTest {
 
-  /**
-   * Checks if {@link TraceSdk#initSessionManager()} inits the Session.
-   */
+  @Before
+  public void before() {
+    TraceSdk.reset();
+  }
+
+  @Test
+  public void reset() {
+    TraceSdk.traceSdk = Mockito.mock(TraceSdk.class);
+    TraceSdk.reset();
+    assertNull(TraceSdk.traceSdk);
+    assertFalse(TraceSdk.isInitialised());
+  }
+
   @Test
   public void initSessionManager_SessionShouldNotBeNull() {
     TraceSdk.initSessionManager();
     final Session actualResult = ApplicationSessionManager.getInstance().getActiveSession();
     assertThat(actualResult, is(notNullValue()));
   }
+
+  @Test
+  public void setDebugEnabled() {
+    TraceSdk.setDebugEnabled(true);
+    assertTrue(TraceSdk.isDebugEnabled());
+
+    TraceSdk.setDebugEnabled(false);
+    assertFalse(TraceSdk.isDebugEnabled());
+  }
+
+  @Test
+  public void initLogger_debugMode() {
+    ConfigurationManager.getDebugInstance("token", Collections.singletonMap("DEBUG", true));
+    TraceSdk.initLogger();
+
+    assertTrue(ConfigurationManager.getInstance().isAppDebugBuild());
+    assertTrue(TraceLog.getLogger() instanceof AndroidLogger);
+  }
+
+  @Test
+  public void initLogger_notDebugMode() {
+    ConfigurationManager.getDebugInstance("token", Collections.singletonMap("DEBUG", false));
+    TraceSdk.initLogger();
+
+    assertFalse(ConfigurationManager.getInstance().isAppDebugBuild());
+    assertTrue(TraceLog.getLogger() instanceof ErrorOnlyLogger);
+  }
+
+  @Test
+  public void initDataCollection() {
+    final DataManager mockDataManager = Mockito.mock(DataManager.class);
+    DataManager.setTestInstance(mockDataManager);
+    final Context mockContext = Mockito.mock(Context.class);
+
+    TraceSdk.initDataCollection(mockContext);
+
+    verify(mockDataManager, times(1)).startCollection(mockContext);
+    verify(mockDataManager, times(1)).startSending(mockContext);
+  }
+
+  @Test
+  public void initLifeCycleListener_fromContextApplication() {
+    final Application mockApplication = Mockito.mock(Application.class);
+    TraceSdk.initLifeCycleListener((Context) mockApplication);
+
+    verify(mockApplication, times(1))
+        .registerActivityLifecycleCallbacks(any());
+  }
+
+  @Test
+  public void initLifeCycleListener_fromContextGetApplicationContext() {
+    final Application mockApplication = Mockito.mock(Application.class);
+    final Context mockContext = Mockito.mock(Context.class);
+
+    when(mockContext.getApplicationContext()).thenReturn(mockApplication);
+    TraceSdk.initLifeCycleListener(mockContext);
+
+    verify(mockApplication, times(1))
+        .registerActivityLifecycleCallbacks(any());
+  }
+
+  @Test
+  public void initLifeCycleListener_noApplicationFromContext() {
+    final Context mockContext = Mockito.mock(Context.class);
+
+    TraceSdk.initLifeCycleListener(mockContext);
+
+    verify(mockContext, times(1)).getApplicationContext();
+    verifyNoMoreInteractions(mockContext);
+  }
+
 }

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
@@ -1,0 +1,207 @@
+package io.bitrise.trace.data.management;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import io.bitrise.trace.configuration.ConfigurationManager;
+import io.bitrise.trace.data.collector.DataCollector;
+import io.bitrise.trace.data.collector.DataListener;
+import io.bitrise.trace.data.collector.memory.MemoryDataCollector;
+import io.bitrise.trace.data.collector.network.okhttp.OkHttpDataListener;
+import io.bitrise.trace.data.collector.view.ApplicationStartUpDataListener;
+import io.bitrise.trace.data.dto.Data;
+import io.bitrise.trace.data.dto.NetworkData;
+import io.bitrise.trace.data.storage.TraceDataStorage;
+import io.bitrise.trace.scheduler.ExecutorScheduler;
+import io.bitrise.trace.scheduler.ServiceScheduler;
+import io.bitrise.trace.session.ApplicationSessionManager;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link DataManager}.
+ */
+public class DataManagerTest {
+
+  final DataManager mockDataManager = Mockito.mock(DataManager.class);
+  final ConfigurationManager mockConfigurationManager = Mockito.mock(ConfigurationManager.class);
+  final Context mockContext = Mockito.mock(Context.class);
+
+  @AfterClass
+  public static void resetAfterAllTests() {
+    DataManager.reset();
+  }
+
+  private DataManager createRealDataManager() {
+    DataManager.reset();
+    final DataManager dataManager = DataManager.getInstance(mockContext);
+    dataManager.configurationManager = mockConfigurationManager;
+
+    ApplicationSessionManager.getInstance().startSession();
+    dataManager.traceManager.startTrace();
+
+    return dataManager;
+  }
+
+  @Test
+  public void getInstance() {
+    DataManager.setTestInstance(mockDataManager);
+    assertEquals(mockDataManager, DataManager.getInstance(mockContext));
+  }
+
+  @Test
+  public void isInitialised_true() {
+    DataManager.setTestInstance(mockDataManager);
+    assertTrue(DataManager.isInitialised());
+  }
+
+  @Test
+  public void isInitialised_false() {
+    DataManager.reset();
+    assertFalse(DataManager.isInitialised());
+  }
+
+  @Test
+  public void reset_everythingInitialised() {
+    final ExecutorScheduler mockExecutorScheduler = Mockito.mock(ExecutorScheduler.class);
+    final ServiceScheduler mockMetricServiceScheduler = Mockito.mock(ServiceScheduler.class);
+    final ServiceScheduler mockTraceServiceScheduler = Mockito.mock(ServiceScheduler.class);
+
+    DataManager.setTestInstance(mockDataManager);
+    mockDataManager.executorScheduler = mockExecutorScheduler;
+    mockDataManager.metricServiceScheduler = mockMetricServiceScheduler;
+    mockDataManager.traceServiceScheduler = mockTraceServiceScheduler;
+
+    DataManager.reset();
+
+    verify(mockDataManager, times(1)).stopCollection();
+    verify(mockExecutorScheduler, times(1)).cancelAll();
+    verify(mockMetricServiceScheduler, times(1)).cancelAll();
+    verify(mockTraceServiceScheduler, times(1)).cancelAll();
+
+    assertNull(mockDataManager.executorScheduler);
+    assertNull(mockDataManager.metricServiceScheduler);
+    assertNull(mockDataManager.traceServiceScheduler);
+    assertFalse(DataManager.isInitialised());
+  }
+
+  @Test
+  public void reset_nothingInitialised() {
+    DataManager.reset();
+    assertFalse(DataManager.isInitialised());
+    DataManager.reset();
+    assertFalse(DataManager.isInitialised());
+  }
+
+  @Test
+  public void setDataStorage() {
+    final DataManager mockDataManager = Mockito.mock(DataManager.class, Mockito.CALLS_REAL_METHODS);
+    final TraceDataStorage mockDataStorage = Mockito.mock(TraceDataStorage.class);
+    mockDataManager.setDataStorage(mockDataStorage);
+    assertEquals(mockDataStorage, mockDataManager.dataStorage);
+  }
+
+  // region collections
+
+  @Test
+  public void startCollection_hasCollectorsAndListenersAlready() {
+    final DataManager dataManager = createRealDataManager();
+
+    dataManager.activeDataCollectors.add(Mockito.mock(MemoryDataCollector.class));
+    dataManager.activeDataListeners.add(Mockito.mock(ApplicationStartUpDataListener.class));
+
+    dataManager.startCollection(mockContext);
+
+    assertEquals(1, dataManager.activeDataCollectors.size());
+    assertEquals(1, dataManager.activeDataListeners.size());
+  }
+
+  @Test
+  public void startCollecting_noCurrentCollectorsOrListeners() {
+    final DataCollector mockCollector = Mockito.mock(MemoryDataCollector.class);
+    final Set<DataCollector> collectors = new HashSet<>();
+    collectors.add(mockCollector);
+
+    final DataListener dataListener = Mockito.mock(ApplicationStartUpDataListener.class);
+    final LinkedHashSet<DataListener> listeners = new LinkedHashSet<>();
+    listeners.add(dataListener);
+
+    when(mockConfigurationManager.getDataCollectors(any())).thenReturn(collectors);
+    when(mockConfigurationManager.getDataListeners(any())).thenReturn(listeners);
+
+    final DataManager dataManager = createRealDataManager();
+    dataManager.startCollection(mockContext);
+
+    assertEquals(collectors, dataManager.getActiveDataCollectors());
+    assertEquals(listeners, dataManager.getActiveDataListeners());
+  }
+
+  @Test
+  public void stopCollecting() {
+    final DataManager dataManager = createRealDataManager();
+
+    dataManager.activeDataCollectors.add(Mockito.mock(MemoryDataCollector.class));
+    dataManager.activeDataListeners.add(Mockito.mock(ApplicationStartUpDataListener.class));
+
+    dataManager.stopCollection();
+
+    assertEquals(0, dataManager.getActiveDataCollectors().size());
+    assertEquals(0, dataManager.getActiveDataListeners().size());
+  }
+
+  //endregion
+
+  // region handleReceivedData
+
+  @Test
+  public void handleReceivedData_trace() {
+    final DataManager dataManager = createRealDataManager();
+    assertNotNull(dataManager.traceManager.getActiveTrace());
+    assertEquals(0, dataManager.traceManager.getActiveTrace().getSpanList().size());
+
+    dataManager.handleReceivedData(createNetworkSpanData());
+
+    assertEquals(1, dataManager.traceManager.getActiveTrace().getSpanList().size());
+  }
+
+  private Data createNetworkSpanData() {
+    final Data data = new Data(OkHttpDataListener.class);
+    final NetworkData networkData = new NetworkData("spanId", "parentSpanId");
+    networkData.setUrl("url");
+    networkData.setMethod("GET");
+    networkData.setStatusCode(202);
+    networkData.setStart(1000L);
+    networkData.setEnd(2000L);
+    data.setContent(networkData);
+    return data;
+  }
+
+  @Test
+  public void handleReceivedData_nullContent() {
+    final DataManager dataManager = createRealDataManager();
+    dataManager.handleReceivedData(createNullContentData());
+
+    assertNotNull(dataManager.traceManager.getActiveTrace());
+    assertEquals(0, dataManager.traceManager.getActiveTrace().getSpanList().size());
+  }
+
+  private Data createNullContentData() {
+    final Data data = new Data(OkHttpDataListener.class);
+    data.setContent(null);
+    return data;
+  }
+
+  //endregion
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/session/ApplicationSessionManagerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/session/ApplicationSessionManagerTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -101,5 +103,30 @@ public class ApplicationSessionManagerTest {
     sessionManager.startSession();
     final Session actualResult = sessionManager.getActiveSession();
     assertThat(actualResult, not(equalTo(expectedValue)));
+  }
+
+  @Test
+  public void reset_sessionManagerIsNotNull() {
+    sessionManager.startSession();
+    assertTrue(ApplicationSessionManager.isSessionManagerActive());
+    assertTrue(ApplicationSessionManager.isSessionActive());
+
+    ApplicationSessionManager.reset();
+
+    assertFalse(ApplicationSessionManager.isSessionManagerActive());
+    assertFalse(ApplicationSessionManager.isSessionActive());
+  }
+
+  @Test
+  public void reset_sessionManagerIsAlreadyNull() {
+    ApplicationSessionManager.reset();
+
+    assertFalse(ApplicationSessionManager.isSessionManagerActive());
+    assertFalse(ApplicationSessionManager.isSessionActive());
+
+    ApplicationSessionManager.reset();
+
+    assertFalse(ApplicationSessionManager.isSessionManagerActive());
+    assertFalse(ApplicationSessionManager.isSessionActive());
   }
 }

--- a/trace-sdk/src/test/java/io/bitrise/trace/utils/log/TraceLogTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/utils/log/TraceLogTest.java
@@ -43,10 +43,10 @@ public class TraceLogTest {
   }
 
   @Test
-  public void makeSilentLogger_alreadyAndroidLogger() {
+  public void makeSilentLogger_butAlreadyAndroidLoggerShouldChange() {
     TraceLog.makeAndroidLogger();
     TraceLog.makeSilentLogger();
-    assertTrue(TraceLog.getLogger() instanceof AndroidLogger);
+    assertTrue(TraceLog.getLogger() instanceof SilentLogger);
   }
 
   @Test


### PR DESCRIPTION
Class | Coverage Before | Coverage After
--- | --- | ---
DataManager | 79.25% | 91.82%
TraceActivityLifecycleTracer | 98.67% | no change
TraceSdk | 8.77% | 69.49%
 ApplicationSessionManager | 70.59% | 100.00%


Mostly improved coverage around the DataManager and TraceSdk.

There are still some areas that are more difficult to test e.g. the TraceSdk init method - as we can't inject mocks or change  the underlying objects such as a ConfigurationManager - and that causes issues. 