### PR TITLE
chore: add TraceExceptionDataListener to data listeners 

### DIFF
--- a/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
@@ -12,6 +12,7 @@ import io.bitrise.trace.data.collector.application.ApplicationVersionCodeDataCol
 import io.bitrise.trace.data.collector.application.ApplicationVersionNameDataCollector;
 import io.bitrise.trace.data.collector.cpu.ApplicationCpuUsageDataCollector;
 import io.bitrise.trace.data.collector.cpu.SystemCpuUsageDataCollector;
+import io.bitrise.trace.data.collector.crash.TraceExceptionDataListener;
 import io.bitrise.trace.data.collector.device.DeviceCarrierDataCollector;
 import io.bitrise.trace.data.collector.device.DeviceIdDataCollector;
 import io.bitrise.trace.data.collector.device.DeviceLocaleDataCollector;
@@ -299,6 +300,7 @@ public class ConfigurationManager {
     dataListeners.add(applicationForegroundStateDataListener);
     dataListeners.add(new FragmentStateDataListener(context, activityStateDataListener));
     dataListeners.add(new OkHttpDataListener(context));
+    dataListeners.add(new TraceExceptionDataListener());
     return dataListeners;
   }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListener.java
@@ -1,0 +1,55 @@
+package io.bitrise.trace.data.collector.crash;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import io.bitrise.trace.data.collector.BaseDataListener;
+import io.bitrise.trace.data.dto.CrashData;
+import io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatter;
+
+/**
+ * Listens for any unhandled exceptions that get thrown and passes them to the
+ * {@link ExceptionDataFormatter}.
+ */
+public class TraceExceptionDataListener extends BaseDataListener
+    implements Thread.UncaughtExceptionHandler {
+
+  @VisibleForTesting
+  @Nullable
+  Thread.UncaughtExceptionHandler previousHandler;
+
+  @Override
+  public void uncaughtException(@NonNull Thread t,
+                                @NonNull Throwable e) {
+
+    onDataCollected(new CrashData(e, Thread.getAllStackTraces()));
+
+    // if there is another handler - we should be good citizens and pass it down to them too.
+    if (previousHandler != null) {
+      previousHandler.uncaughtException(t, e);
+    }
+  }
+
+  public void onDataCollected(final @NonNull CrashData crashData) {
+    dataManager.handleReceivedCrash(crashData);
+  }
+
+  @Override
+  public void startCollecting() {
+    previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+    Thread.setDefaultUncaughtExceptionHandler(this);
+    setActive(true);
+  }
+
+  @Override
+  public void stopCollecting() {
+    Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+    setActive(false);
+  }
+
+  @NonNull
+  @Override
+  public String[] getPermissions() {
+    return new String[0];
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListener.java
@@ -5,11 +5,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.bitrise.trace.data.collector.BaseDataListener;
 import io.bitrise.trace.data.dto.CrashData;
-import io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatter;
 
 /**
- * Listens for any unhandled exceptions that get thrown and passes them to the
- * {@link ExceptionDataFormatter}.
+ * Listens for any unhandled exceptions that get thrown.
  */
 public class TraceExceptionDataListener extends BaseDataListener
     implements Thread.UncaughtExceptionHandler {

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/package-info.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/crash/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Responsible for crashes and exception collection.
+ */
+
+package io.bitrise.trace.data.collector.crash;

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/dto/CrashData.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/dto/CrashData.java
@@ -1,0 +1,32 @@
+package io.bitrise.trace.data.dto;
+
+import androidx.annotation.NonNull;
+import java.util.Map;
+
+/**
+ * Data object that contains the original information from a crash.
+ */
+public class CrashData {
+
+  @NonNull
+  private final Throwable throwable;
+
+  @NonNull
+  private final Map<Thread, StackTraceElement[]> allStackTraces;
+
+  public CrashData(@NonNull Throwable throwable, @NonNull
+      Map<Thread, StackTraceElement[]> allStackTraces) {
+    this.throwable = throwable;
+    this.allStackTraces = allStackTraces;
+  }
+
+  @NonNull
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  @NonNull
+  public Map<Thread, StackTraceElement[]> getAllStackTraces() {
+    return allStackTraces;
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/dto/CrashReport.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/dto/CrashReport.java
@@ -1,0 +1,33 @@
+package io.bitrise.trace.data.dto;
+
+import androidx.annotation.NonNull;
+import java.util.Map;
+
+/**
+ * Data object that contains a formatted crash report to send to the backend.
+ */
+public class CrashReport {
+
+  @NonNull
+  final String throwable;
+
+  @NonNull
+  final Map<String, String> threads;
+
+
+  public CrashReport(@NonNull final String throwable,
+                     @NonNull final Map<String, String> threads) {
+    this.throwable = throwable;
+    this.threads = threads;
+  }
+
+  @NonNull
+  public String getThrowable() {
+    return throwable;
+  }
+
+  @NonNull
+  public Map<String, String> getThreads() {
+    return threads;
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -8,8 +8,11 @@ import io.bitrise.trace.configuration.ConfigurationManager;
 import io.bitrise.trace.data.collector.DataCollector;
 import io.bitrise.trace.data.collector.DataListener;
 import io.bitrise.trace.data.collector.DataSource;
+import io.bitrise.trace.data.dto.CrashData;
+import io.bitrise.trace.data.dto.CrashReport;
 import io.bitrise.trace.data.dto.Data;
 import io.bitrise.trace.data.dto.FormattedData;
+import io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatter;
 import io.bitrise.trace.data.storage.DataStorage;
 import io.bitrise.trace.data.storage.TraceDataStorage;
 import io.bitrise.trace.data.trace.ApplicationTraceManager;
@@ -367,5 +370,10 @@ public class DataManager {
                  .execute(() -> dataStorage.saveFormattedData(formattedData));
       }
     }
+  }
+
+  public void handleReceivedCrash(final @NonNull CrashData crashData) {
+    final CrashReport crashReport = ExceptionDataFormatter.formatCrashData(crashData);
+    // todo: APM-1843 send the crash report.
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
@@ -1,7 +1,6 @@
 package io.bitrise.trace.data.management.formatter.crash;
 
 import androidx.annotation.NonNull;
-import com.google.common.base.Throwables;
 import io.bitrise.trace.data.dto.CrashData;
 import io.bitrise.trace.data.dto.CrashReport;
 import java.util.Map;
@@ -19,7 +18,8 @@ public class ExceptionDataFormatter {
    */
   public static CrashReport formatCrashData(final @NonNull CrashData crashData) {
 
-    final String throwable = Throwables.getStackTraceAsString(crashData.getThrowable());
+    final String throwable = StackTraceElementUtil
+            .createStringifiedStackTrace(crashData.getThrowable().getStackTrace());
     final Map<String, String> threads =
         StackTraceElementUtil.createStringifiedReport(crashData.getAllStackTraces());
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
@@ -6,8 +6,17 @@ import io.bitrise.trace.data.dto.CrashData;
 import io.bitrise.trace.data.dto.CrashReport;
 import java.util.Map;
 
+/**
+ * Formats {@link CrashData} objects into {@link CrashReport} objects.
+ */
 public class ExceptionDataFormatter {
 
+  /**
+   * Formats a {@link CrashData} object into a {@link CrashReport} object.
+   *
+   * @param crashData the original crash data.
+   * @return the formatted {@link CrashReport} object.
+   */
   public static CrashReport formatCrashData(final @NonNull CrashData crashData) {
 
     final String throwable = Throwables.getStackTraceAsString(crashData.getThrowable());

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatter.java
@@ -1,0 +1,19 @@
+package io.bitrise.trace.data.management.formatter.crash;
+
+import androidx.annotation.NonNull;
+import com.google.common.base.Throwables;
+import io.bitrise.trace.data.dto.CrashData;
+import io.bitrise.trace.data.dto.CrashReport;
+import java.util.Map;
+
+public class ExceptionDataFormatter {
+
+  public static CrashReport formatCrashData(final @NonNull CrashData crashData) {
+
+    final String throwable = Throwables.getStackTraceAsString(crashData.getThrowable());
+    final Map<String, String> threads =
+        StackTraceElementUtil.createStringifiedReport(crashData.getAllStackTraces());
+
+    return new CrashReport(throwable, threads);
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtil.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtil.java
@@ -21,11 +21,9 @@ public class StackTraceElementUtil {
     final Map<String, String> map = new HashMap<>();
 
     for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
-
       final String stringifiedStackTrace = createStringifiedStackTrace(entry.getValue());
       final String threadId = Long.toString(entry.getKey().getId());
       map.put(threadId, stringifiedStackTrace);
-
     }
 
     return map;
@@ -35,11 +33,10 @@ public class StackTraceElementUtil {
    * Creates a String from a list of {@link StackTraceElement}.
    *
    * @param stackTraceElements the StackTraceElements to convert to String.
-   * @return the stringied representation of the stackTraceElements.
+   * @return the stringified representation of the stackTraceElements.
    */
   public static String createStringifiedStackTrace(
       @NonNull StackTraceElement[] stackTraceElements) {
-
     final StringBuilder sb = new StringBuilder();
 
     for (int i = 0; i < stackTraceElements.length; i++) {

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtil.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtil.java
@@ -1,0 +1,55 @@
+package io.bitrise.trace.data.management.formatter.crash;
+
+import androidx.annotation.NonNull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility method to convert {@link StackTraceElement}'s into Strings.
+ */
+public class StackTraceElementUtil {
+
+  /**
+   * Creates a Map of String to String from a map of Thread to StackTraceElement[]. The resulting
+   * map will use the key from the Thread id, and stringified StackTraceElement[].
+   *
+   * @param allStackTraces the result of calling <code>Thread.getAllStackTraces()</code>.
+   * @return the map of thread id to stringified StackTraceElement[].
+   */
+  public static Map<String, String> createStringifiedReport(
+      @NonNull Map<Thread, StackTraceElement[]> allStackTraces) {
+    final Map<String, String> map = new HashMap<>();
+
+    for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
+
+      final String stringifiedStackTrace = createStringifiedStackTrace(entry.getValue());
+      final String threadId = Long.toString(entry.getKey().getId());
+      map.put(threadId, stringifiedStackTrace);
+
+    }
+
+    return map;
+  }
+
+  /**
+   * Creates a String from a list of {@link StackTraceElement}.
+   *
+   * @param stackTraceElements the StackTraceElements to convert to String.
+   * @return the stringied representation of the stackTraceElements.
+   */
+  public static String createStringifiedStackTrace(
+      @NonNull StackTraceElement[] stackTraceElements) {
+
+    final StringBuilder sb = new StringBuilder();
+
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      sb.append(stackTraceElements[i].toString());
+
+      if (i != (stackTraceElements.length) - 1) {
+        sb.append("\n");
+      }
+    }
+
+    return sb.toString();
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/package-info.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/formatter/crash/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Responsible for formatting crash collection reports.
+ */
+
+package io.bitrise.trace.data.management.formatter.crash;

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListenerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/collector/crash/TraceExceptionDataListenerTest.java
@@ -1,0 +1,77 @@
+package io.bitrise.trace.data.collector.crash;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.bitrise.trace.data.dto.CrashData;
+import io.bitrise.trace.data.management.DataManager;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link TraceExceptionDataListener}.
+ */
+public class TraceExceptionDataListenerTest {
+
+  final Thread mockThread = Mockito.mock(Thread.class);
+  final Throwable throwable = new Throwable();
+  final DataManager mockDataManager = Mockito.mock(DataManager.class);
+  final TraceExceptionDataListener listener = new TraceExceptionDataListener();
+
+
+  @Test
+  public void uncaughtException_withPreviousHandler() {
+    final TraceExceptionDataListener mockListener = Mockito.mock(TraceExceptionDataListener.class,
+        Mockito.CALLS_REAL_METHODS);
+
+    final Thread.UncaughtExceptionHandler previousHandler =
+        Mockito.mock(Thread.UncaughtExceptionHandler.class);
+    mockListener.setDataManager(mockDataManager);
+    mockListener.previousHandler = previousHandler;
+
+    mockListener.uncaughtException(mockThread, throwable);
+
+    verify(mockListener, times(1))
+        .onDataCollected(new CrashData(throwable, any()));
+    verify(previousHandler, times(1))
+        .uncaughtException(any(), any());
+  }
+
+  @Test
+  public void uncaughtException_noPreviousHandler() {
+    final TraceExceptionDataListener mockListener = Mockito.mock(TraceExceptionDataListener.class,
+        Mockito.CALLS_REAL_METHODS);
+
+    mockListener.setDataManager(mockDataManager);
+    mockListener.previousHandler = null;
+
+    mockListener.uncaughtException(mockThread, throwable);
+
+    verify(mockListener, times(1))
+        .onDataCollected(new CrashData(throwable, any()));
+  }
+
+  @Test
+  public void startAndStopCollecting() {
+    final TraceExceptionDataListener mockListener = Mockito.mock(TraceExceptionDataListener.class,
+        Mockito.CALLS_REAL_METHODS);
+
+    assertFalse(mockListener.isActive());
+
+    mockListener.startCollecting();
+    assertTrue(mockListener.isActive());
+
+    mockListener.stopCollecting();
+    assertFalse(mockListener.isActive());
+  }
+
+  @Test
+  public void getPermissions() {
+    assertArrayEquals(new String[0], listener.getPermissions());
+  }
+
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/CrashFormatterTestProvider.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/CrashFormatterTestProvider.java
@@ -5,16 +5,16 @@ package io.bitrise.trace.data.management.formatter.crash;
  */
 public class CrashFormatterTestProvider {
 
-  final static String expectedStringifiedStackTrace = "class1.method1(file1:1)\n" +
-      "class2.method2(filename2:2)\n" +
-      "class3.method3(filename3:3)";
+  static final String expectedStringifiedStackTrace = "class1.method1(file1:1)\n"
+      + "class2.method2(filename2:2)\n"
+      + "class3.method3(filename3:3)";
 
   static StackTraceElement[] createStackTraceElements() {
     final StackTraceElement[] list = new StackTraceElement[3];
 
-    list[0] = new StackTraceElement("class1", "method1", "file1" ,1);
-    list[1] = new StackTraceElement("class2", "method2", "filename2" ,2);
-    list[2] = new StackTraceElement("class3", "method3", "filename3" ,3);
+    list[0] = new StackTraceElement("class1", "method1", "file1", 1);
+    list[1] = new StackTraceElement("class2", "method2", "filename2", 2);
+    list[2] = new StackTraceElement("class3", "method3", "filename3", 3);
 
     return list;
   }

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/CrashFormatterTestProvider.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/CrashFormatterTestProvider.java
@@ -1,0 +1,22 @@
+package io.bitrise.trace.data.management.formatter.crash;
+
+/**
+ * Provides test data for the crash formatter tests.
+ */
+public class CrashFormatterTestProvider {
+
+  final static String expectedStringifiedStackTrace = "class1.method1(file1:1)\n" +
+      "class2.method2(filename2:2)\n" +
+      "class3.method3(filename3:3)";
+
+  static StackTraceElement[] createStackTraceElements() {
+    final StackTraceElement[] list = new StackTraceElement[3];
+
+    list[0] = new StackTraceElement("class1", "method1", "file1" ,1);
+    list[1] = new StackTraceElement("class2", "method2", "filename2" ,2);
+    list[2] = new StackTraceElement("class3", "method3", "filename3" ,3);
+
+    return list;
+  }
+
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
@@ -16,49 +16,17 @@ import org.mockito.Mockito;
  */
 public class ExceptionDataFormatterTest {
 
-  private final String expectedThrowableString = "java.lang.Throwable\n"
-      + "\tat io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatterTest"
-      + ".formatCrashData_noMessageInThrowable(ExceptionDataFormatterTest.java:59)\n"
-      + "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n"
-      + "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke"
-      + "(NativeMethodAccessorImpl.java:62)\n"
-      + "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke"
-      + "(DelegatingMethodAccessorImpl.java:43)\n"
-      + "\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n"
-      + "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)"
-      + "\n"
-      + "\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n"
-      + "\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n"
-      + "\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n"
-      + "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n"
-      + "\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)"
-      + "\n"
-      + "\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n"
-      + "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n"
-      + "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n"
-      + "\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n"
-      + "\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n"
-      + "\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n"
-      + "\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n"
-      + "\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n"
-      + "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n"
-      + "\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n"
-      + "\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n"
-      + "\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner"
-      + ".java:69)\n"
-      + "\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner"
-      + ".java:33)\n"
-      + "\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)\n"
-      + "\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)\n";
-
   @Test
-  public void formatCrashData_noMessageInThrowable() {
+  public void formatCrashData() {
     final Map<Thread, StackTraceElement[]> allStackTraces = new HashMap<>();
     final Thread mockThread = Mockito.mock(Thread.class);
     allStackTraces.put(mockThread, CrashFormatterTestProvider.createStackTraceElements());
-    final CrashData input = new CrashData(new Throwable(), allStackTraces);
+    final Throwable mockThrowable = Mockito.mock(Throwable.class);
+    final CrashData input = new CrashData(mockThrowable, allStackTraces);
 
     when(mockThread.getId()).thenReturn(12345L);
+    when(mockThrowable.getStackTrace())
+        .thenReturn(CrashFormatterTestProvider.createStackTraceElements());
 
     final CrashReport result = ExceptionDataFormatter.formatCrashData(input);
 
@@ -68,7 +36,7 @@ public class ExceptionDataFormatterTest {
     expectedThreads.put("12345", CrashFormatterTestProvider.expectedStringifiedStackTrace);
 
     assertEquals(result.getThreads(), expectedThreads);
-    assertEquals(expectedThrowableString, result.getThrowable());
+    assertEquals(result.getThrowable(), CrashFormatterTestProvider.expectedStringifiedStackTrace);
   }
 
 

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
@@ -1,0 +1,76 @@
+package io.bitrise.trace.data.management.formatter.crash;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import io.bitrise.trace.data.dto.CrashData;
+import io.bitrise.trace.data.dto.CrashReport;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link ExceptionDataFormatter}.
+ */
+public class ExceptionDataFormatterTest {
+
+  private final String expectedThrowableString = "java.lang.Throwable\n" +
+      "\tat io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatterTest" +
+      ".formatCrashData_noMessageInThrowable(ExceptionDataFormatterTest.java:59)\n" +
+      "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
+      "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke" +
+      "(NativeMethodAccessorImpl.java:62)\n" +
+      "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke" +
+      "(DelegatingMethodAccessorImpl.java:43)\n" +
+      "\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n" +
+      "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)" +
+      "\n" +
+      "\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n" +
+      "\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n" +
+      "\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n" +
+      "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n" +
+      "\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)" +
+      "\n" +
+      "\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n" +
+      "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n" +
+      "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n" +
+      "\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n" +
+      "\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n" +
+      "\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n" +
+      "\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n" +
+      "\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n" +
+      "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n" +
+      "\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n" +
+      "\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n" +
+      "\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner" +
+      ".java:69)\n" +
+      "\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner" +
+      ".java:33)\n" +
+      "\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)\n" +
+      "\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)\n";
+
+  @Test
+  public void formatCrashData_noMessageInThrowable() {
+    final Map<Thread, StackTraceElement[]> allStackTraces = new HashMap<>();
+    final Thread mockThread = Mockito.mock(Thread.class);
+    allStackTraces.put(mockThread, CrashFormatterTestProvider.createStackTraceElements());
+    final CrashData input = new CrashData(new Throwable(), allStackTraces);
+
+    when(mockThread.getId()).thenReturn(12345L);
+
+    final CrashReport result = ExceptionDataFormatter.formatCrashData(input);
+
+    assertNotNull(result);
+
+    final Map<String, String> expectedThreads = new HashMap<>();
+    expectedThreads.put("12345", CrashFormatterTestProvider.expectedStringifiedStackTrace);
+
+    assertEquals(result.getThreads(), expectedThreads);
+    assertEquals(expectedThrowableString, result.getThrowable());
+  }
+
+
+
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/ExceptionDataFormatterTest.java
@@ -16,40 +16,40 @@ import org.mockito.Mockito;
  */
 public class ExceptionDataFormatterTest {
 
-  private final String expectedThrowableString = "java.lang.Throwable\n" +
-      "\tat io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatterTest" +
-      ".formatCrashData_noMessageInThrowable(ExceptionDataFormatterTest.java:59)\n" +
-      "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n" +
-      "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke" +
-      "(NativeMethodAccessorImpl.java:62)\n" +
-      "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke" +
-      "(DelegatingMethodAccessorImpl.java:43)\n" +
-      "\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n" +
-      "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)" +
-      "\n" +
-      "\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n" +
-      "\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n" +
-      "\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n" +
-      "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n" +
-      "\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)" +
-      "\n" +
-      "\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n" +
-      "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n" +
-      "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n" +
-      "\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n" +
-      "\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n" +
-      "\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n" +
-      "\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n" +
-      "\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n" +
-      "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n" +
-      "\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n" +
-      "\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n" +
-      "\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner" +
-      ".java:69)\n" +
-      "\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner" +
-      ".java:33)\n" +
-      "\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)\n" +
-      "\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)\n";
+  private final String expectedThrowableString = "java.lang.Throwable\n"
+      + "\tat io.bitrise.trace.data.management.formatter.crash.ExceptionDataFormatterTest"
+      + ".formatCrashData_noMessageInThrowable(ExceptionDataFormatterTest.java:59)\n"
+      + "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\n"
+      + "\tat java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke"
+      + "(NativeMethodAccessorImpl.java:62)\n"
+      + "\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke"
+      + "(DelegatingMethodAccessorImpl.java:43)\n"
+      + "\tat java.base/java.lang.reflect.Method.invoke(Method.java:566)\n"
+      + "\tat org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)"
+      + "\n"
+      + "\tat org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)\n"
+      + "\tat org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)\n"
+      + "\tat org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)\n"
+      + "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n"
+      + "\tat org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)"
+      + "\n"
+      + "\tat org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)\n"
+      + "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)\n"
+      + "\tat org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)\n"
+      + "\tat org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)\n"
+      + "\tat org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)\n"
+      + "\tat org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)\n"
+      + "\tat org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)\n"
+      + "\tat org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)\n"
+      + "\tat org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)\n"
+      + "\tat org.junit.runners.ParentRunner.run(ParentRunner.java:413)\n"
+      + "\tat org.junit.runner.JUnitCore.run(JUnitCore.java:137)\n"
+      + "\tat com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner"
+      + ".java:69)\n"
+      + "\tat com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner"
+      + ".java:33)\n"
+      + "\tat com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)\n"
+      + "\tat com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)\n";
 
   @Test
   public void formatCrashData_noMessageInThrowable() {

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtilTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/formatter/crash/StackTraceElementUtilTest.java
@@ -1,0 +1,46 @@
+package io.bitrise.trace.data.management.formatter.crash;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link StackTraceElementUtil}.
+ */
+public class StackTraceElementUtilTest {
+
+
+  @Test
+  public void createStringifiedReport() {
+    final Map<Thread, StackTraceElement[]> input = new HashMap<>();
+    final Thread mockThread = Mockito.mock(Thread.class);
+    input.put(mockThread, CrashFormatterTestProvider.createStackTraceElements());
+
+    when(mockThread.getId()).thenReturn(12345L);
+
+    final Map<String, String> expectedResult = new HashMap<>();
+    expectedResult.put("12345", CrashFormatterTestProvider.expectedStringifiedStackTrace);
+
+    assertEquals(expectedResult, StackTraceElementUtil.createStringifiedReport(input));
+  }
+
+  @Test
+  public void createStringifiedStackTrace_withEmptyStackTraces() {
+    final String result = StackTraceElementUtil
+        .createStringifiedStackTrace(new StackTraceElement[0]);
+    assertEquals("", result);
+  }
+
+  @Test
+  public void createStringifiedStackTrace_withStackTraces() {
+    final String result = StackTraceElementUtil
+        .createStringifiedStackTrace(CrashFormatterTestProvider.createStackTraceElements());
+    assertEquals(CrashFormatterTestProvider.expectedStringifiedStackTrace, result);
+  }
+
+}


### PR DESCRIPTION
Adds the TraceExceptionDataListener to the list of dataListeners in the CollectionManager.

These in turn then call startCollecting and stopCollecting in the DataManager appropriately.