### PR TITLE
fix: datamanager resource bug

### DIFF
--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
@@ -126,7 +126,7 @@ public class DataManagerInstrumentedTest {
     sleep(100);
     // this happens asynchronously, and can take a few milliseconds to actually get called.
 
-    final ArgumentCaptor<MetricEntity>  metricEntityArgumentCaptor=
+    final ArgumentCaptor<MetricEntity> metricEntityArgumentCaptor =
         ArgumentCaptor.forClass(MetricEntity.class);
     verify(mockDataStorage, times(1))
         .saveMetric(metricEntityArgumentCaptor.capture());

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/management/DataManagerInstrumentedTest.java
@@ -15,7 +15,8 @@ import io.bitrise.trace.data.collector.DataSourceType;
 import io.bitrise.trace.data.collector.DummyDataCollector;
 import io.bitrise.trace.data.collector.DummyDataListener;
 import io.bitrise.trace.data.dto.Data;
-import io.bitrise.trace.data.dto.FormattedData;
+import io.bitrise.trace.data.metric.MetricEntity;
+import io.bitrise.trace.data.resource.ResourceEntity;
 import io.bitrise.trace.data.storage.DataStorage;
 import io.bitrise.trace.scheduler.ServiceScheduler;
 import io.bitrise.trace.session.ApplicationSessionManager;
@@ -125,10 +126,36 @@ public class DataManagerInstrumentedTest {
     sleep(100);
     // this happens asynchronously, and can take a few milliseconds to actually get called.
 
-    final ArgumentCaptor<FormattedData> formattedDataArgumentCaptor =
-        ArgumentCaptor.forClass(FormattedData.class);
+    final ArgumentCaptor<MetricEntity>  metricEntityArgumentCaptor=
+        ArgumentCaptor.forClass(MetricEntity.class);
     verify(mockDataStorage, times(1))
-        .saveFormattedData(formattedDataArgumentCaptor.capture());
-    assertNotNull(formattedDataArgumentCaptor.getValue().getMetricEntity());
+        .saveMetric(metricEntityArgumentCaptor.capture());
+    assertNotNull(metricEntityArgumentCaptor.getValue());
+  }
+
+  /**
+   * When the {@link DataManager#handleReceivedData(Data)} is called with a valid {@link Data}
+   * that will be converted to a {@link io.opencensus.proto.resource.v1.Resource} it should not
+   * throw an exception and call the relevant database save method.
+   */
+  @Test
+  public void handleReceivedData_shouldHandleResource() throws InterruptedException {
+    DataManager.getInstance(context);
+    ApplicationSessionManager.getInstance().startSession();
+    final DataStorage mockDataStorage = Mockito.mock(DataStorage.class);
+    dataManager.setDataStorage(mockDataStorage);
+
+    final Data data = new Data(DataSourceType.APP_VERSION_CODE);
+    data.setContent("123");
+    dataManager.handleReceivedData(data);
+
+    sleep(100);
+    // this happens asynchronously, and can take a few milliseconds to actually get called.
+
+    final ArgumentCaptor<ResourceEntity>  resourceEntityArgumentCaptor =
+        ArgumentCaptor.forClass(ResourceEntity.class);
+    verify(mockDataStorage, times(1))
+        .saveResourceEntity(resourceEntityArgumentCaptor.capture());
+    assertNotNull(resourceEntityArgumentCaptor.getValue());
   }
 }

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/TraceDataStorageInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/TraceDataStorageInstrumentedTest.java
@@ -91,48 +91,6 @@ public class TraceDataStorageInstrumentedTest {
     MatcherAssert.assertThat(actualValue, sameInstance(expectedValue));
   }
 
-  @Test
-  public void saveFormattedData_null() {
-    dataStorage.saveFormattedData(null);
-    assertEquals(0, dataStorage.getAllMetrics().size());
-    assertEquals(0, dataStorage.getAllResources().size());
-    assertEquals(0, dataStorage.getAllTraces().size());
-  }
-
-  @Test
-  public void saveFormattedData_metric() {
-    final FormattedData formattedData = new FormattedData(
-        MetricTestProvider.getApplicationStartUpMetric());
-    dataStorage.saveFormattedData(formattedData);
-    assertEquals(1, dataStorage.getAllMetrics().size());
-    assertEquals(MetricTestProvider.getApplicationStartUpMetric(),
-        dataStorage.getAllMetrics().get(0).getMetric());
-    assertEquals(0, dataStorage.getAllResources().size());
-    assertEquals(0, dataStorage.getAllTraces().size());
-  }
-
-  @Test
-  public void saveFormattedData_resource() {
-    final FormattedData formattedData = new FormattedData(
-        DataTestUtils.getSampleResourceEntity());
-    dataStorage.saveFormattedData(formattedData);
-    assertEquals(0, dataStorage.getAllMetrics().size());
-    assertEquals(1, dataStorage.getAllResources().size());
-    assertEquals(DataTestUtils.getSampleResourceEntity(),
-        dataStorage.getAllResources().get(0));
-    assertEquals(0, dataStorage.getAllTraces().size());
-  }
-
-  @Test
-  public void saveFormattedData_span() {
-    final FormattedData formattedData = new FormattedData(
-        TraceTestProvider.createNetworkSpan());
-    dataStorage.saveFormattedData(formattedData);
-    assertEquals(0, dataStorage.getAllMetrics().size());
-    assertEquals(0, dataStorage.getAllResources().size());
-    assertEquals(0, dataStorage.getAllTraces().size());
-  }
-
   /**
    * Asserts that if we add a {@link Metric} to the {@link TraceDatabase} via the
    * {@link TraceDataStorage} it will be returned when we query it.

--- a/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
@@ -257,17 +257,27 @@ public class ConfigurationManager {
    * @return the DataCollectors.
    */
   @NonNull
-  public Set<DataCollector> getDataCollectors(@NonNull final Context context) {
+  public Set<DataCollector> getRecurringDataCollectors(@NonNull final Context context) {
     final Set<DataCollector> dataCollectors = new HashSet<>();
     dataCollectors.add(new ApplicationUsedMemoryDataCollector(context));
     dataCollectors.add(new SystemMemoryDataCollector(context));
-
     dataCollectors.add(new SystemCpuUsageDataCollector());
     dataCollectors.add(new ApplicationCpuUsageDataCollector());
+    return dataCollectors;
+  }
 
+  /**
+   * Creates a new set of {@link DataCollector}s that only need to collect their data once during
+   * the lifecycle of the application e.g. Application version codes.
+   *
+   * @param context the Android Context.
+   * @return the DataCollectors.
+   */
+  @NonNull
+  public Set<DataCollector> getSingleDataCollectors(@NonNull final Context context) {
+    final Set<DataCollector> dataCollectors = new HashSet<>();
     dataCollectors.add(new ApplicationVersionNameDataCollector(context));
     dataCollectors.add(new ApplicationVersionCodeDataCollector(context));
-
     dataCollectors.add(new DeviceModelDataCollector());
     dataCollectors.add(new DeviceOsVersionDataCollector());
     dataCollectors.add(new DeviceNetworkTypeDataCollector(context));

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -370,7 +370,8 @@ public class DataManager {
     final FormattedData[] formattedDataArray = dataFormatterDelegator.formatData(data);
 
     if (formattedDataArray.length == 0) {
-      TraceLog.d("Formatted data, but result content was null: " + data.getDataSourceType().toString());
+      TraceLog.d("Formatted data, but result content was null: "
+          + data.getDataSourceType().toString());
       return;
     }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -355,7 +355,7 @@ public class DataManager {
     final FormattedData[] formattedDataArray = dataFormatterDelegator.formatData(data);
 
     if (formattedDataArray.length == 0) {
-      TraceLog.d("Formatted data, but result content was null: " + data);
+      TraceLog.d("Formatted data, but result content was null: " + data.getDataSourceType().toString());
       return;
     }
 
@@ -364,7 +364,10 @@ public class DataManager {
         traceManager.addSpanToActiveTrace(formattedData.getSpan());
       } else if (formattedData.getMetricEntity() != null) {
         Executors.newSingleThreadExecutor()
-                 .execute(() -> dataStorage.saveFormattedData(formattedData));
+                 .execute(() -> dataStorage.saveMetric(formattedData.getMetricEntity()));
+      } else if (formattedData.getResourceEntity() != null) {
+        Executors.newSingleThreadExecutor()
+                 .execute(() -> dataStorage.saveResourceEntity(formattedData.getResourceEntity()));
       }
     }
   }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -205,6 +205,8 @@ public class DataManager {
     TraceLog.d(LogMessageConstants.DATA_MANAGER_START_COLLECTING);
     startEventDrivenDataCollection(context);
     startRecurringDataCollection(context);
+
+    collectDataFromSingleCollectors(context);
   }
 
   /**
@@ -228,13 +230,26 @@ public class DataManager {
         return;
       }
 
-      activeDataCollectors.addAll(configurationManager.getDataCollectors(context));
+      activeDataCollectors.addAll(configurationManager.getRecurringDataCollectors(context));
       for (@NonNull final DataCollector dataCollector : activeDataCollectors) {
         final Runnable collectDataRunnable = () -> handleReceivedData(dataCollector.collectData());
         executorScheduler = new ExecutorScheduler(context, collectDataRunnable, 0,
             dataCollector.getIntervalMs());
         executorScheduler.schedule();
       }
+    }
+  }
+
+  /**
+   * Collects data from the single collectors, these are data that do not change during the
+   * application lifecycle e.g. Application version code.
+   *
+   * @param context the Android Context.
+   */
+  void collectDataFromSingleCollectors(@NonNull final Context context) {
+    final Set<DataCollector> collectors = configurationManager.getSingleDataCollectors(context);
+    for (DataCollector collector : collectors) {
+      handleReceivedData(collector.collectData());
     }
   }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/storage/DataStorage.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/storage/DataStorage.java
@@ -40,29 +40,6 @@ public abstract class DataStorage {
   }
 
   /**
-   * Saves the given {@link FormattedData} to the storage. {@link Trace}s and Spans are not saved
-   * directly to the DataStorage, they should be sent to the {@link TraceManager}.
-   *
-   * <p>Should not be called on the main thread.
-   *
-   * @param formattedData the FormattedData.
-   */
-  @WorkerThread
-  public void saveFormattedData(@Nullable final FormattedData formattedData) {
-    if (formattedData == null) {
-      return;
-    }
-
-    if (formattedData.getMetricEntity() != null) {
-      saveMetric(formattedData.getMetricEntity());
-    } else if (formattedData.getResourceEntity() != null) {
-      saveResourceEntity(formattedData.getResourceEntity());
-    } else if (formattedData.getSpan() != null) {
-      TraceLog.e(new TraceException.FormattedDataSpanNonNullException(formattedData.getSpan()));
-    }
-  }
-
-  /**
    * Saves the given {@link MetricEntity} to the storage.
    *
    * <p>Should not be called on the main thread.

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
@@ -138,7 +138,7 @@ public class DataManagerTest {
     final LinkedHashSet<DataListener> listeners = new LinkedHashSet<>();
     listeners.add(dataListener);
 
-    when(mockConfigurationManager.getDataCollectors(any())).thenReturn(collectors);
+    when(mockConfigurationManager.getRecurringDataCollectors(any())).thenReturn(collectors);
     when(mockConfigurationManager.getDataListeners(any())).thenReturn(listeners);
 
     final DataManager dataManager = createRealDataManager();


### PR DESCRIPTION
It looks like I introduced a bug whilst writing the unit tests for this class, this meant resources are no longer being saved to the data storage. This PR ensures they now get saved, and has a test for them too.

I also optimised the resource collection - these are items that do not change during the application lifecycle so don't need to be regularly collected. Collecting them once when Trace starts is fine. 