### PR TITLE
fix: minified client apps should work

### DIFF
--- a/trace-sdk/build.gradle
+++ b/trace-sdk/build.gradle
@@ -26,7 +26,7 @@ android {
         }
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
         }
     }
     compileOptions {

--- a/trace-sdk/proguard-rules.pro
+++ b/trace-sdk/proguard-rules.pro
@@ -22,3 +22,5 @@
 
 # To avoid obfuscation of the TraceSdk class that would lead to issues in byte code modification.
 -keep public class io.bitrise.trace.TraceSdk
+-keep public class io.opencensus.proto.** { *; }
+-keep public class com.google.protobuf.** { *; }

--- a/trace-sdk/proguard-rules.pro
+++ b/trace-sdk/proguard-rules.pro
@@ -24,3 +24,4 @@
 -keep public class io.bitrise.trace.TraceSdk
 -keep public class io.opencensus.proto.** { *; }
 -keep public class com.google.protobuf.** { *; }
+-keep public class io.bitrise.trace.network.** { *; }

--- a/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/configuration/ConfigurationManager.java
@@ -276,8 +276,12 @@ public class ConfigurationManager {
   @NonNull
   public Set<DataCollector> getSingleDataCollectors(@NonNull final Context context) {
     final Set<DataCollector> dataCollectors = new HashSet<>();
-    dataCollectors.add(new ApplicationVersionNameDataCollector(context));
-    dataCollectors.add(new ApplicationVersionCodeDataCollector(context));
+    dataCollectors.add(new ApplicationVersionNameDataCollector(
+        context.getPackageManager(),
+        context.getPackageName()));
+    dataCollectors.add(new ApplicationVersionCodeDataCollector(
+        context.getPackageManager(),
+        context.getPackageName()));
     dataCollectors.add(new DeviceModelDataCollector());
     dataCollectors.add(new DeviceOsVersionDataCollector());
     dataCollectors.add(new DeviceNetworkTypeDataCollector(context));

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionCodeDataCollector.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionCodeDataCollector.java
@@ -1,8 +1,7 @@
 package io.bitrise.trace.data.collector.application;
 
-import android.content.Context;
+import android.content.pm.PackageManager;
 import androidx.annotation.NonNull;
-import io.bitrise.trace.configuration.ConfigurationManager;
 import io.bitrise.trace.data.collector.DataCollector;
 import io.bitrise.trace.data.dto.Data;
 
@@ -11,16 +10,19 @@ import io.bitrise.trace.data.dto.Data;
  */
 public class ApplicationVersionCodeDataCollector extends ApplicationDataCollector {
 
-  @NonNull
-  private final Context context;
+  @NonNull private final PackageManager packageManager;
+  @NonNull private final String packageName;
 
   /**
    * Constructor for class.
    *
-   * @param context the Android Context.
+   * @param packageManager - the customer application {@link PackageManager}.
+   * @param packageName - the customer application package name.
    */
-  public ApplicationVersionCodeDataCollector(@NonNull final Context context) {
-    this.context = context;
+  public ApplicationVersionCodeDataCollector(@NonNull final PackageManager packageManager,
+                                             @NonNull final String packageName) {
+    this.packageManager = packageManager;
+    this.packageName = packageName;
   }
 
   @NonNull
@@ -44,9 +46,10 @@ public class ApplicationVersionCodeDataCollector extends ApplicationDataCollecto
    */
   @NonNull
   private String getAppVersionCode() {
-    if (!ConfigurationManager.isInitialised()) {
-      ConfigurationManager.init(context);
+    try {
+      return String.valueOf(packageManager.getPackageInfo(packageName, 0).versionCode);
+    } catch (PackageManager.NameNotFoundException e) {
+      return "unknown";
     }
-    return String.valueOf(ConfigurationManager.getInstance().getConfigItem("VERSION_CODE"));
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollector.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollector.java
@@ -1,8 +1,7 @@
 package io.bitrise.trace.data.collector.application;
 
-import android.content.Context;
+import android.content.pm.PackageManager;
 import androidx.annotation.NonNull;
-import io.bitrise.trace.configuration.ConfigurationManager;
 import io.bitrise.trace.data.collector.DataCollector;
 import io.bitrise.trace.data.dto.Data;
 
@@ -11,16 +10,19 @@ import io.bitrise.trace.data.dto.Data;
  */
 public class ApplicationVersionNameDataCollector extends ApplicationDataCollector {
 
-  @NonNull
-  private final Context context;
+  @NonNull private final PackageManager packageManager;
+  @NonNull private final String packageName;
 
   /**
    * Constructor for class.
    *
-   * @param context the Android Context.
+   * @param packageManager - the customer application {@link PackageManager}.
+   * @param packageName - the customer application package name.
    */
-  public ApplicationVersionNameDataCollector(@NonNull final Context context) {
-    this.context = context;
+  public ApplicationVersionNameDataCollector(@NonNull final PackageManager packageManager,
+                                             @NonNull final String packageName) {
+   this.packageManager = packageManager;
+   this.packageName = packageName;
   }
 
   @NonNull
@@ -44,9 +46,10 @@ public class ApplicationVersionNameDataCollector extends ApplicationDataCollecto
    */
   @NonNull
   private String getAppVersionName() {
-    if (!ConfigurationManager.isInitialised()) {
-      ConfigurationManager.init(context);
+    try {
+      return packageManager.getPackageInfo(packageName, 0).versionName;
+    } catch (PackageManager.NameNotFoundException e) {
+      return "unknown";
     }
-    return (String) ConfigurationManager.getInstance().getConfigItem("VERSION_NAME");
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollector.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollector.java
@@ -21,8 +21,8 @@ public class ApplicationVersionNameDataCollector extends ApplicationDataCollecto
    */
   public ApplicationVersionNameDataCollector(@NonNull final PackageManager packageManager,
                                              @NonNull final String packageName) {
-   this.packageManager = packageManager;
-   this.packageName = packageName;
+    this.packageManager = packageManager;
+    this.packageName = packageName;
   }
 
   @NonNull

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/MetricRequest.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/MetricRequest.java
@@ -1,6 +1,7 @@
 package io.bitrise.trace.network;
 
 import androidx.annotation.NonNull;
+import com.google.gson.annotations.SerializedName;
 import io.opencensus.proto.metrics.v1.Metric;
 import io.opencensus.proto.resource.v1.Resource;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
  */
 public class MetricRequest extends NetworkRequest {
 
+  @SerializedName("metrics")
   @NonNull
   private final List<Metric> metrics;
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkRequest.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkRequest.java
@@ -1,6 +1,7 @@
 package io.bitrise.trace.network;
 
 import androidx.annotation.NonNull;
+import com.google.gson.annotations.SerializedName;
 import io.opencensus.proto.resource.v1.Resource;
 
 /**
@@ -8,6 +9,7 @@ import io.opencensus.proto.resource.v1.Resource;
  */
 public abstract class NetworkRequest {
 
+  @SerializedName("resource")
   @NonNull
   Resource resource;
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/TraceRequest.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/TraceRequest.java
@@ -1,6 +1,7 @@
 package io.bitrise.trace.network;
 
 import androidx.annotation.NonNull;
+import com.google.gson.annotations.SerializedName;
 import io.bitrise.trace.data.trace.Trace;
 import io.opencensus.proto.resource.v1.Resource;
 import io.opencensus.proto.trace.v1.Span;
@@ -11,6 +12,7 @@ import java.util.List;
  */
 public class TraceRequest extends NetworkRequest {
 
+  @SerializedName("spans")
   @NonNull
   private final List<Span> spans;
 

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/application/ApplicationVersionCodeDataCollectorTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/application/ApplicationVersionCodeDataCollectorTest.java
@@ -2,14 +2,12 @@ package io.bitrise.trace.data.application;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
-import android.content.Context;
-import io.bitrise.trace.BuildConfig;
-import io.bitrise.trace.configuration.ConfigurationManager;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import io.bitrise.trace.data.collector.application.ApplicationVersionCodeDataCollector;
 import io.bitrise.trace.data.dto.Data;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -19,23 +17,23 @@ import org.mockito.Mockito;
 public class ApplicationVersionCodeDataCollectorTest {
 
   private static final int versionCode = 123;
-  private final Context mockContext = Mockito.mock(Context.class);
+  private final PackageManager mockPackageManager = Mockito.mock(PackageManager.class);
+  private final String packageName = "packageName";
   private final ApplicationVersionCodeDataCollector collector =
-      new ApplicationVersionCodeDataCollector(
-          mockContext);
+      new ApplicationVersionCodeDataCollector(mockPackageManager, packageName);
 
   @Test
-  public void collectData_configurationManagerInitialised() {
-    final Map<String, Object> configuration = new HashMap<>();
-    configuration.put("VERSION_CODE", versionCode);
-    ConfigurationManager.getDebugInstance(BuildConfig.TRACE_TOKEN, configuration);
+  public void collectData_configurationManagerInitialised()
+      throws PackageManager.NameNotFoundException {
+    final PackageInfo packageInfo = new PackageInfo();
+    packageInfo.versionCode = versionCode;
+    when(mockPackageManager.getPackageInfo(packageName, 0))
+        .thenReturn(packageInfo);
 
     final Data expectedData = new Data(ApplicationVersionCodeDataCollector.class);
     expectedData.setContent(String.valueOf(versionCode));
 
     assertEquals(expectedData, collector.collectData());
-
-    ConfigurationManager.reset();
   }
 
   @Test

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/application/ApplicationVersionNameDataCollectorTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/application/ApplicationVersionNameDataCollectorTest.java
@@ -2,14 +2,12 @@ package io.bitrise.trace.data.application;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
-import android.content.Context;
-import io.bitrise.trace.BuildConfig;
-import io.bitrise.trace.configuration.ConfigurationManager;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import io.bitrise.trace.data.collector.application.ApplicationVersionNameDataCollector;
 import io.bitrise.trace.data.dto.Data;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -19,23 +17,23 @@ import org.mockito.Mockito;
 public class ApplicationVersionNameDataCollectorTest {
 
   private static final String versionName = "1.2.3";
-  private final Context mockContext = Mockito.mock(Context.class);
+  private final PackageManager mockPackageManager = Mockito.mock(PackageManager.class);
+  private final String packageName = "packageName";
   private final ApplicationVersionNameDataCollector collector =
-      new ApplicationVersionNameDataCollector(
-          mockContext);
+      new ApplicationVersionNameDataCollector(mockPackageManager, packageName);
 
   @Test
-  public void collectData_configurationManagerInitialised() {
-    final Map<String, Object> configuration = new HashMap<>();
-    configuration.put("VERSION_NAME", versionName);
-    ConfigurationManager.getDebugInstance(BuildConfig.TRACE_TOKEN, configuration);
+  public void collectData_configurationManagerInitialised()
+      throws PackageManager.NameNotFoundException {
+    final PackageInfo packageInfo = new PackageInfo();
+    packageInfo.versionName = versionName;
+    when(mockPackageManager.getPackageInfo(packageName, 0))
+        .thenReturn(packageInfo);
 
     final Data expectedData = new Data(ApplicationVersionNameDataCollector.class);
     expectedData.setContent(versionName);
 
     assertEquals(expectedData, collector.collectData());
-
-    ConfigurationManager.reset();
   }
 
   @Test

--- a/trace-test-application/src/androidTest/java/io/bitrise/trace/data/collector/application/ApplicationVersionCodeDataCollectorInstrumentedTest.java
+++ b/trace-test-application/src/androidTest/java/io/bitrise/trace/data/collector/application/ApplicationVersionCodeDataCollectorInstrumentedTest.java
@@ -28,7 +28,8 @@ public class ApplicationVersionCodeDataCollectorInstrumentedTest {
   @Test
   public void collectData_contentShouldMatch() {
     final ApplicationVersionCodeDataCollector applicationVersionCodeDataCollector =
-        new ApplicationVersionCodeDataCollector(context);
+        new ApplicationVersionCodeDataCollector(
+            context.getPackageManager(), context.getPackageName());
     final String actualValue =
         (String) applicationVersionCodeDataCollector.collectData().getContent();
     final String expectedValue = "1";

--- a/trace-test-application/src/androidTest/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollectorInstrumentedTest.java
+++ b/trace-test-application/src/androidTest/java/io/bitrise/trace/data/collector/application/ApplicationVersionNameDataCollectorInstrumentedTest.java
@@ -28,7 +28,8 @@ public class ApplicationVersionNameDataCollectorInstrumentedTest {
   @Test
   public void collectData_contentShouldMatch() {
     final ApplicationVersionNameDataCollector applicationVersionNameDataCollector =
-        new ApplicationVersionNameDataCollector(context);
+        new ApplicationVersionNameDataCollector(
+            context.getPackageManager(), context.getPackageName());
     final String actualValue =
         (String) applicationVersionNameDataCollector.collectData().getContent();
     final String expectedValue = "1.0";


### PR DESCRIPTION
This PR fixes the four issues with customers using trace in a minified app - separated the fixes into different commits.

1. We needed to use `consumerProguardFiles` to let consumers merge correctly with our proguard rules

2. Updated our proguard rules to keep the protocol buffer classes.

3. Added SerializedName annotations to keep the naming strategy for objects that get sent (`resources` because `a` which was not accepted by the back end).

4. Application version code and version name were being retrieved from the configuration manager by string. Unfortunately `"VERSION_NAME"` gets turned into something we don't know upfront. Used an alternate way of retrieving this information that doesn't depend on constants. Also updated the tests.


Have tested with deploying the pineapple app in release with the flag "minified true" - set all the log messages to e level so they would appear in the log cat:

<img width="1552" alt="Screenshot 2021-07-01 at 16 13 25" src="https://user-images.githubusercontent.com/71286749/124152953-ddb70300-da8b-11eb-81a9-a1c12fdd4463.png">

This has shown up in the dashboard as:

<img width="1128" alt="Screenshot 2021-07-01 at 16 45 15" src="https://user-images.githubusercontent.com/71286749/124153018-f0c9d300-da8b-11eb-9c9c-48630ae7265b.png">
<img width="1124" alt="Screenshot 2021-07-01 at 16 45 21" src="https://user-images.githubusercontent.com/71286749/124153032-f4f5f080-da8b-11eb-9666-84cd3bb5d264.png">

which indicates all data is being sent as expected.
