### PR TITLE
build: release opencensus 1.0.2 and trace-sdk 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ trace-android-sdk public beta versions
 **Note:** these versions of the *trace-android-sdk* are stored in a public repo, but should be 
 considered still as beta.
 
+### trace-sdk - 0.2.1 - 2021-07-02
+* fix: **trace-sdk should work on minified client apps:** Updated proguard rules and ensured data gets sent correctly to the backend.
+* fix: **use java lite protocol buffer dependencies:** Recompile proto files to java lite instead of java.
+* fix: **datamanager resource bug:** Fix datamanager bug not saving resource entities.
+* fix: **DataManagerInstrumentedTest bug:** Fixed an occasional issue in the DataManagerInstrumentedTest.
+
 ### trace-sdk - 0.2.0 - 2021-04-15
 * feat: **Support Android version 21:** Update minSdkVersion to 21 for trace-sdk and trace-test-application
 


### PR DESCRIPTION
PR to release new versions of opencensus (1.0.2) and trace-sdk (0.2.1).


Checklist before release:

- [x] compiles debug mode
- [x] debug data in dashboard (session 01F9KN7TY3DW381H5Z80CK1TSW)
- [x] compiles release mode
- [x] release data in dashboard (session 01F9KNFETRXNXH187ZKFP616HY)
- [x] compiles with firebase dependencies
- [x] debug + firebase deps data in dashboard (session 01F9KNZWH69SB916CTK23H1ZCG)
