### PR TITLE
feat: enable options when initialising the trace sdk 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,6 @@ Use Trace to:
 * SDK uses AndroidX libraries, there could be issues when integrating it to an app with the 
 deprecated Android support libraries.
 
-## Debug mode
-
-The TraceSdk has a debug mode - currently this will mean more debug level log messages.
-
-Please note if you are not using a debug build, and or minify is enabled it can affect these logs, and they can be stripped out depending on your configuration
-You also need to ensure that the TraceSdk has been initialised before setting the debug enabled mode.
-
-To enable this add the following to your project e.g. in your MainActivity:
-
-```java
-TraceSdk.setDebugEnabled(true)
-```
-
-Note: You can enable and disable debug mode anywhere in your application, this could be the first activity, or a specific activity later in the application lifecycle.
 
 ## Installation
 
@@ -106,6 +92,40 @@ version.
 5. The first time you run the application, the build will take several minutes longer than normal 
 while the Trace SDK applies the plugin. 
 6. Check your logcat messages, Trace should now be working
+
+## Options
+
+You can customise some of the Trace sdk behaviour.
+
+You will need to manually initialise the sdk, ideally in a your own Application classes `onCreate`
+function e.g.
+
+```
+TraceSdk.init(applicationContext)
+```
+
+You can then pass in an optional list of `TraceOption` objects. The following options can be added:
+
+* `TraceOption.DebugMode` - boolean - default set to false.
+    * This puts the Trace sdk into a debug mode, which currently prints more debug messages into
+    the log cat.
+* `TraceOption.NetworkUrlConnectionTracing` - boolean - default set to true.
+    * This will disable any network tracing for UrlConnection events. This can be useful if you are
+    experiencing any issues with third party libraries.
+
+e.g. to initialise trace with the debug mode option:
+
+```
+TraceSdk.init(
+    applicationContext,
+    listOf(
+        TraceOption.DebugMode(true)
+    )
+)
+```
+
+Note: It is possible to add multiple of the same type of option to the list, however only the first
+object affects the behaviour of the sdk, any subsequent objects will be ignored.
 
 ## License
 Trace is released under the MIT license. See 

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
@@ -1,13 +1,13 @@
 package io.bitrise.trace;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import androidx.test.platform.app.InstrumentationRegistry;
 import io.bitrise.trace.configuration.ConfigurationManager;
-import io.bitrise.trace.utils.log.TraceLog;
+import java.util.Collections;
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +33,14 @@ public class TraceSdkInstrumentedTest {
 
   @Test
   public void initNetworkTracing() {
-    TraceSdk.initNetworkTracing();
+    TraceSdk.initNetworkTracing(null);
     assertTrue(TraceSdk.isNetworkTracingEnabled);
+  }
+
+  @Test
+  public void initNetworkTracing_whenOptionDisabled() {
+    TraceSdk.initNetworkTracing(Collections.singletonList(
+        new TraceOption.NetworkUrlConnectionTracing(false)));
+    assertFalse(TraceSdk.isNetworkTracingEnabled);
   }
 }

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/TraceSdkInstrumentedTest.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import androidx.test.platform.app.InstrumentationRegistry;
 import io.bitrise.trace.configuration.ConfigurationManager;
 import java.util.Collections;
-import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
@@ -1,0 +1,37 @@
+package io.bitrise.trace;
+
+import androidx.annotation.VisibleForTesting;
+
+/**
+ * Object for providing options when initialising the trace sdk. TraceOption should not be
+ * directly created, but there should be individual objects for each type of option which extend
+ * from the TraceOption object.
+ */
+public class TraceOption {
+
+  private final Object value;
+
+  public Object getValue() {
+    return value;
+  }
+
+  // this should not be used by anyone
+  @VisibleForTesting
+  protected TraceOption(Object value) {
+    this.value = value;
+  }
+
+  /**
+   * Option object for customising whether the trace sdk should trace URL Connection type network
+   * events.
+   */
+  public static class NetworkUrlConnectionTracing extends TraceOption {
+    public NetworkUrlConnectionTracing(boolean isEnabled) {
+      super(isEnabled);
+    }
+  }
+
+
+
+}
+

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
@@ -31,7 +31,17 @@ public class TraceOption {
     }
   }
 
-
-
+  /**
+   * Option object for putting trace into a debug mode - currently this will mean more
+   * debug level log messages.
+   *
+   * Please note if you are not using a debug build, and or minify is enabled it can affect
+   * these logs, and they can be stripped out depending on your configuration.
+   */
+  public static class DebugMode extends TraceOption {
+    public DebugMode(boolean isEnabled) {
+      super(isEnabled);
+    }
+  }
 }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOption.java
@@ -35,7 +35,7 @@ public class TraceOption {
    * Option object for putting trace into a debug mode - currently this will mean more
    * debug level log messages.
    *
-   * Please note if you are not using a debug build, and or minify is enabled it can affect
+   * <p>Please note if you are not using a debug build, and or minify is enabled it can affect
    * these logs, and they can be stripped out depending on your configuration.
    */
   public static class DebugMode extends TraceOption {

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
@@ -13,10 +13,10 @@ public class TraceOptionsUtil {
    *
    * @param options the complete list of options provided when the sdk was initialised.
    * @return true by default, and false if the {@link TraceOption.NetworkUrlConnectionTracing}
-   * object has been created and set to false.
+   *     object has been created and set to false.
    */
   protected static boolean determineIfNetworkUrlConnectionTracing(
-       @Nullable final List<TraceOption> options) {
+      @Nullable final List<TraceOption> options) {
 
     if (options == null || options.size() == 0) {
       return true;
@@ -36,7 +36,7 @@ public class TraceOptionsUtil {
    *
    * @param options the complete list of options provided when the sdk was initialised.
    * @return false by default, and true if the {@link TraceOption.DebugMode} object has been created
-   * and set to to true.
+   *     and set to to true.
    */
   protected static boolean determineIfDebugMode(@Nullable final List<TraceOption> options) {
     if (options == null || options.size() == 0) {

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
@@ -1,0 +1,34 @@
+package io.bitrise.trace;
+
+import androidx.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Utility object for working with {@link TraceOption}s.
+ */
+public class TraceOptionsUtil {
+
+  /**
+   * Determines if the sdk should trace {@link java.net.URLConnection} type network events.
+   *
+   * @param options the complete list of options provided when the sdk was initialised.
+   * @return true by default, and false if the {@link TraceOption.NetworkUrlConnectionTracing}
+   *      object has been created and set to false.
+   */
+  protected static boolean determineIfNetworkUrlConnectionTracing(
+       @Nullable final List<TraceOption> options) {
+
+    if (options == null || options.size() == 0) {
+      return true;
+    }
+
+    for (TraceOption option : options) {
+      if (option instanceof TraceOption.NetworkUrlConnectionTracing) {
+        return (Boolean) option.getValue();
+      }
+    }
+
+    return true;
+  }
+
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceOptionsUtil.java
@@ -13,7 +13,7 @@ public class TraceOptionsUtil {
    *
    * @param options the complete list of options provided when the sdk was initialised.
    * @return true by default, and false if the {@link TraceOption.NetworkUrlConnectionTracing}
-   *      object has been created and set to false.
+   * object has been created and set to false.
    */
   protected static boolean determineIfNetworkUrlConnectionTracing(
        @Nullable final List<TraceOption> options) {
@@ -29,6 +29,27 @@ public class TraceOptionsUtil {
     }
 
     return true;
+  }
+
+  /**
+   * Determines if the sdk should be in debug mode or not.
+   *
+   * @param options the complete list of options provided when the sdk was initialised.
+   * @return false by default, and true if the {@link TraceOption.DebugMode} object has been created
+   * and set to to true.
+   */
+  protected static boolean determineIfDebugMode(@Nullable final List<TraceOption> options) {
+    if (options == null || options.size() == 0) {
+      return false;
+    }
+
+    for (TraceOption option : options) {
+      if (option instanceof TraceOption.DebugMode) {
+        return (Boolean) option.getValue();
+      }
+    }
+
+    return false;
   }
 
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -37,16 +37,15 @@ public class TraceSdk {
   @VisibleForTesting
   @Nullable
   static volatile TraceSdk traceSdk;
+
   /**
-   * The TraceSdk has a debug mode - currently this will mean more debug level log messages.
-   *
-   * <p>Please note if you are not using a debug build, and or minify is enabled it can affect
-   * these logs, and they can be stripped out depending on your configuration. You also need to
-   * ensure that the TraceSdk has been initialised before setting the debug enabled mode.
+   * Boolean to determine if the customer enabled debug mode for the TraceSdk.
    */
-  private static boolean DEBUG_ENABLED = false;
+  private static boolean isDebugModeEnabled = false;
 
-
+  /**
+   * Boolean to determine if the UrlConnection tracing was initialised successfully.
+   */
   static boolean isNetworkTracingEnabled = false;
 
   private TraceSdk() {
@@ -79,6 +78,8 @@ public class TraceSdk {
 
     if (ConfigurationManager.isInitialised()) {
 
+      isDebugModeEnabled = TraceOptionsUtil.determineIfDebugMode(options);
+
       initLogger();
 
       TraceLog.i(LogMessageConstants.INITIALISING_SDK);
@@ -89,7 +90,7 @@ public class TraceSdk {
       initDataCollection(context);
       initLifeCycleListener(context);
       initNetworkTracing(options);
-      TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, DEBUG_ENABLED));
+      TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, isDebugModeEnabled));
     } else {
       TraceLog.e(new TraceException.TraceConfigNotInitialisedException());
     }
@@ -100,22 +101,8 @@ public class TraceSdk {
    *
    * @return whether the sdk is in debug mode.
    */
-  public static boolean isDebugEnabled() {
-    return DEBUG_ENABLED;
-  }
-
-  /**
-   * Flag to enable debug mode - currently this will mean more debug level log messages.
-   *
-   * <p>Please note if you are not using a debug build, and or minify is enabled it can affect
-   * these logs, and they can be stripped out depending on your configuration. You also need to
-   * ensure that the TraceSdk has been initialised before setting the debug enabled mode.
-   *
-   * @param debugEnabled boolean value to enable or disable debug mode in the TraceSdk.
-   */
-  public static synchronized void setDebugEnabled(final boolean debugEnabled) {
-    DEBUG_ENABLED = debugEnabled;
-    TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, DEBUG_ENABLED));
+  public static boolean isDebugModeEnabled() {
+    return isDebugModeEnabled;
   }
 
   /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -152,6 +152,7 @@ public class TraceSdk {
     TraceActivityLifecycleTracker.reset();
     ApplicationTraceManager.reset();
     ConfigurationManager.reset();
+    isNetworkTracingEnabled = false;
   }
 
   /**

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/log/TraceLog.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/log/TraceLog.java
@@ -274,7 +274,7 @@ public class TraceLog {
    * @param message the message to log.
    */
   public static void debugV(@NonNull String message) {
-    if (TraceSdk.isDebugEnabled()) {
+    if (TraceSdk.isDebugModeEnabled()) {
       TraceLog.v(message);
     }
   }

--- a/trace-sdk/src/test/java/io/bitrise/trace/TraceOptionsUtilTests.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/TraceOptionsUtilTests.java
@@ -1,0 +1,59 @@
+package io.bitrise.trace;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Tests for {@link TraceOptionsUtil}.
+ */
+public class TraceOptionsUtilTests {
+
+  @Test
+  public void determineIfNetworkUrlConnectionTracing_nullOptions() {
+    assertTrue(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(null));
+  }
+
+  @Test
+  public void determineIfNetworkUrlConnectionTracing_emptyOptions() {
+    assertTrue(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(new ArrayList<>()));
+  }
+
+  @Test
+  public void determineIfNetworkUrlConnectionTracing_optionKeyTrue() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new TraceOption.NetworkUrlConnectionTracing(true));
+
+    assertTrue(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(options));
+  }
+
+  @Test
+  public void determineIfNetworkUrlConnectionTracing_optionKeyFalse() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new TraceOption.NetworkUrlConnectionTracing(false));
+
+    assertFalse(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(options));
+  }
+
+  @Test
+  public void determineIfNetworkUrlConnectionTracing_otherOptions() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new DummyOption());
+
+    assertTrue(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(options));
+  }
+
+
+  /**
+   * private test {@link TraceOption} class.
+   */
+  protected static class DummyOption extends TraceOption {
+    public DummyOption() {
+      super("a value");
+    }
+  }
+
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/TraceOptionsUtilTests.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/TraceOptionsUtilTests.java
@@ -46,6 +46,39 @@ public class TraceOptionsUtilTests {
     assertTrue(TraceOptionsUtil.determineIfNetworkUrlConnectionTracing(options));
   }
 
+  @Test
+  public void determineIfDebugMode_nullOptions() {
+    assertFalse(TraceOptionsUtil.determineIfDebugMode(null));
+  }
+
+  @Test
+  public void determineIfDebugMode_emptyOptions() {
+    assertFalse(TraceOptionsUtil.determineIfDebugMode(new ArrayList<>()));
+  }
+
+  @Test
+  public void determineIfDebugMode_optionKeyTrue() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new TraceOption.DebugMode(true));
+
+    assertTrue(TraceOptionsUtil.determineIfDebugMode(options));
+  }
+
+  @Test
+  public void determineIfDebugMode_optionKeyFalse() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new TraceOption.DebugMode(false));
+
+    assertFalse(TraceOptionsUtil.determineIfDebugMode(options));
+  }
+
+  @Test
+  public void determineIfDebugMode_otherOptions() {
+    final List<TraceOption> options = new ArrayList<>();
+    options.add(new DummyOption());
+
+    assertFalse(TraceOptionsUtil.determineIfDebugMode(options));
+  }
 
   /**
    * private test {@link TraceOption} class.

--- a/trace-sdk/src/test/java/io/bitrise/trace/TraceSdkTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/TraceSdkTest.java
@@ -52,15 +52,6 @@ public class TraceSdkTest {
   }
 
   @Test
-  public void setDebugEnabled() {
-    TraceSdk.setDebugEnabled(true);
-    assertTrue(TraceSdk.isDebugEnabled());
-
-    TraceSdk.setDebugEnabled(false);
-    assertFalse(TraceSdk.isDebugEnabled());
-  }
-
-  @Test
   public void initLogger_debugMode() {
     ConfigurationManager.getDebugInstance("token", Collections.singletonMap("DEBUG", true));
     TraceSdk.initLogger();

--- a/trace-test-application/src/main/java/io/bitrise/trace/testapp/IndexActivity.java
+++ b/trace-test-application/src/main/java/io/bitrise/trace/testapp/IndexActivity.java
@@ -19,8 +19,6 @@ public class IndexActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_index);
 
-    TraceSdk.setDebugEnabled(true);
-
     final Button btnUiTests = findViewById(R.id.btn_ui_tests);
     final Button btnNetworkTests = findViewById(R.id.btn_network_tests);
     final Button btnExceptionTests = findViewById(R.id.btn_exception_tests);


### PR DESCRIPTION
This PR allows customers to provide a list of TraceOptions when they initialise the trace sdk. This can be used to turn features on and off.

Currently, this allows customers to disable Network Tracing URLConnection events, and consolidates the debug mode.


Tested with the pineapple app that this configures trace correctly:
<img width="1460" alt="Screenshot 2021-08-04 at 11 20 28" src="https://user-images.githubusercontent.com/71286749/128165303-a90953b1-1b9e-4fee-9236-b741d4b7c1f4.png">
