### PR TITLE
feat: add trace id and span id to crash reports

### DIFF
--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
@@ -70,8 +70,7 @@ public class ActivityStateDataListener extends BaseDataListener
 
   @Override
   public void stopCollecting() {
-    endAnyActivitiesOpen();
-    flushAllRemainingData();
+    endAnyActivitiesOpenAndFlush();
     traceActivityLifecycleTracker.unregisterTraceActivityLifecycleSink(this);
     setActive(false);
   }
@@ -174,21 +173,16 @@ public class ActivityStateDataListener extends BaseDataListener
     onDataCollected(data);
   }
 
-  private void endAnyActivitiesOpen() {
+  private void endAnyActivitiesOpenAndFlush() {
     if (!activityMap.isEmpty()) {
       for (Map.Entry<Integer, ActivityData> entry : activityMap.entrySet()) {
         entry.getValue().putState(ActivityState.STOPPED, TraceClock.getCurrentTimeMillis());
-      }
-    }
-  }
 
-  private void flushAllRemainingData() {
-    if (! activityMap.isEmpty()) {
-      for (Map.Entry<Integer, ActivityData> entry : activityMap.entrySet()) {
         final Data data = new Data(this);
         data.setContent(entry.getValue());
         onDataCollected(data);
       }
     }
   }
+
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
@@ -175,9 +175,9 @@ public class ActivityStateDataListener extends BaseDataListener
   }
 
   private void endAnyActivitiesOpen() {
-    if (! activityMap.isEmpty()) {
+    if (!activityMap.isEmpty()) {
       for (Map.Entry<Integer, ActivityData> entry : activityMap.entrySet()) {
-         entry.getValue().putState(ActivityState.STOPPED, TraceClock.getCurrentTimeMillis());
+        entry.getValue().putState(ActivityState.STOPPED, TraceClock.getCurrentTimeMillis());
       }
     }
   }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/ActivityStateDataListener.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.bitrise.trace.data.TraceActivityLifecycleTracker;
 import io.bitrise.trace.data.collector.BaseDataListener;
 import io.bitrise.trace.data.collector.TraceActivityLifecycleSink;
@@ -37,7 +38,7 @@ public class ActivityStateDataListener extends BaseDataListener
    * {@link ActivityData}.
    */
   @NonNull
-  final Map<Integer, ActivityData> activityMap;
+  final Map<Integer, ActivityData> activityMap = new HashMap<>();
   /**
    * The {@link TraceActivityLifecycleTracker} for observing the lifecycle state changes.
    */
@@ -57,7 +58,6 @@ public class ActivityStateDataListener extends BaseDataListener
   public ActivityStateDataListener(@NonNull final Context context) {
     this.dataManager = DataManager.getInstance(context);
     this.traceActivityLifecycleTracker = TraceActivityLifecycleTracker.getInstance(context);
-    this.activityMap = new HashMap<>();
     this.traceManager = ApplicationTraceManager.getInstance(context);
   }
 
@@ -70,6 +70,8 @@ public class ActivityStateDataListener extends BaseDataListener
 
   @Override
   public void stopCollecting() {
+    endAnyActivitiesOpen();
+    flushAllRemainingData();
     traceActivityLifecycleTracker.unregisterTraceActivityLifecycleSink(this);
     setActive(false);
   }
@@ -141,7 +143,8 @@ public class ActivityStateDataListener extends BaseDataListener
    *                          to change.
    * @param activityStateType the {@link ActivityState} to add.
    */
-  private void updateActivityMap(final int activityId,
+  @VisibleForTesting
+  void updateActivityMap(final int activityId,
                                  @Nullable final String name,
                                  @NonNull final ActivityState activityStateType) {
     ActivityData activityData = activityMap.get(activityId);
@@ -169,5 +172,23 @@ public class ActivityStateDataListener extends BaseDataListener
     data.setContent(activityMap.get(id));
     activityMap.remove(id);
     onDataCollected(data);
+  }
+
+  private void endAnyActivitiesOpen() {
+    if (! activityMap.isEmpty()) {
+      for (Map.Entry<Integer, ActivityData> entry : activityMap.entrySet()) {
+         entry.getValue().putState(ActivityState.STOPPED, TraceClock.getCurrentTimeMillis());
+      }
+    }
+  }
+
+  private void flushAllRemainingData() {
+    if (! activityMap.isEmpty()) {
+      for (Map.Entry<Integer, ActivityData> entry : activityMap.entrySet()) {
+        final Data data = new Data(this);
+        data.setContent(entry.getValue());
+        onDataCollected(data);
+      }
+    }
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/FragmentStateDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/FragmentStateDataListener.java
@@ -20,6 +20,7 @@ import io.bitrise.trace.data.collector.TraceActivityLifecycleSink;
 import io.bitrise.trace.data.dto.ActivityData;
 import io.bitrise.trace.data.dto.Data;
 import io.bitrise.trace.data.dto.FragmentData;
+import io.bitrise.trace.data.dto.FragmentDataStateEntry;
 import io.bitrise.trace.data.dto.FragmentState;
 import io.bitrise.trace.data.management.DataManager;
 import io.bitrise.trace.data.trace.ApplicationTraceManager;
@@ -48,7 +49,7 @@ public class FragmentStateDataListener extends FragmentManager.FragmentLifecycle
    */
   @VisibleForTesting
   @NonNull
-  final Map<Integer, Map<Integer, FragmentData>> activityFragmentMap;
+  Map<Integer, Map<Integer, FragmentData>> activityFragmentMap;
   /**
    * The {@link TraceActivityLifecycleTracker} to register itself to it's lifecycle event callbacks.
    */
@@ -425,6 +426,30 @@ public class FragmentStateDataListener extends FragmentManager.FragmentLifecycle
   public void stopCollecting() {
     traceActivityLifecycleTracker.unregisterTraceActivityLifecycleSink(this);
     isActive = false;
+    endAnyFragmentsOpenAndFlush();
+  }
+
+  private void endAnyFragmentsOpenAndFlush() {
+
+    // loop through any activities we had open
+    for (Map.Entry<Integer, Map<Integer, FragmentData>> activityEntry :
+        activityFragmentMap.entrySet()) {
+      final Map<Integer, FragmentData> fragmentMap = activityEntry.getValue();
+
+      // loop through any fragments in those activities
+      for (Map.Entry<Integer, FragmentData> fragmentEntry : fragmentMap.entrySet()) {
+        final FragmentData fragmentData = fragmentEntry.getValue();
+
+        // append the stopped state to all the entries
+        fragmentData.addState(new FragmentDataStateEntry(FragmentState.STOPPED, TraceClock.getCurrentTimeMillis()));
+
+        // send the data up
+        final Data data = new Data(this);
+        data.setContent(fragmentData);
+        onDataCollected(data);
+
+      }
+    }
   }
 
   @Override

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/FragmentStateDataListener.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/collector/view/FragmentStateDataListener.java
@@ -441,7 +441,8 @@ public class FragmentStateDataListener extends FragmentManager.FragmentLifecycle
         final FragmentData fragmentData = fragmentEntry.getValue();
 
         // append the stopped state to all the entries
-        fragmentData.addState(new FragmentDataStateEntry(FragmentState.STOPPED, TraceClock.getCurrentTimeMillis()));
+        fragmentData.addState(
+            new FragmentDataStateEntry(FragmentState.STOPPED, TraceClock.getCurrentTimeMillis()));
 
         // send the data up
         final Data data = new Data(this);

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -293,7 +293,7 @@ public class DataManager {
         executorScheduler.cancelAll();
       }
 
-      activeDataCollectors.clear();
+      getActiveDataCollectors().clear();
     }
   }
 
@@ -302,10 +302,10 @@ public class DataManager {
    */
   private void stopEventDrivenDataCollection() {
     synchronized (activeDataListenerLock) {
-      for (@NonNull final DataListener dataListener : activeDataListeners) {
+      for (@NonNull final DataListener dataListener : getActiveDataListeners()) {
         dataListener.stopCollecting();
       }
-      activeDataListeners.clear();
+      getActiveDataListeners().clear();
     }
   }
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/DataManager.java
@@ -27,10 +27,12 @@ import io.bitrise.trace.scheduler.ExecutorScheduler;
 import io.bitrise.trace.scheduler.ServiceScheduler;
 import io.bitrise.trace.session.ApplicationSessionManager;
 import io.bitrise.trace.session.Session;
+import io.bitrise.trace.utils.ByteStringConverter;
 import io.bitrise.trace.utils.log.LogMessageConstants;
 import io.bitrise.trace.utils.log.TraceLog;
 import io.opencensus.proto.metrics.v1.Metric;
 import io.opencensus.proto.resource.v1.Resource;
+import io.opencensus.proto.trace.v1.Span;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -411,6 +413,10 @@ public class DataManager {
    * @param crashData the {@link CrashData} object captured.
    */
   public void handleReceivedCrash(final @NonNull CrashData crashData) {
+
+    //end any current spans and traces
+    stopCollection();
+
     final CrashReport crashReport = CrashDataFormatter.formatCrashData(crashData);
 
     final Session session = ApplicationSessionManager.getInstance().getActiveSession();
@@ -425,7 +431,17 @@ public class DataManager {
       return;
     }
 
-    final CrashSender crashSender = new CrashSender(crashReport, resource);
+    final Trace activeTrace = ApplicationTraceManager.getInstance(context).getActiveTrace();
+    if (activeTrace == null) {
+      TraceLog.d("Data manager: active trace was null.");
+      return;
+    }
+
+    final Span lastSpan = activeTrace.getLastActiveViewSpan();
+
+    final CrashSender crashSender = new CrashSender(
+        crashReport, resource, activeTrace.getTraceId(),
+        lastSpan == null ? "" : ByteStringConverter.toString(lastSpan.getSpanId()));
     crashSender.send();
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/CrashSender.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/CrashSender.java
@@ -2,6 +2,7 @@ package io.bitrise.trace.network;
 
 import androidx.annotation.NonNull;
 import io.bitrise.trace.data.dto.CrashReport;
+import io.bitrise.trace.data.trace.ApplicationTraceManager;
 import io.bitrise.trace.utils.TraceClock;
 import io.bitrise.trace.utils.UniqueIdGenerator;
 import io.bitrise.trace.utils.log.TraceLog;
@@ -23,6 +24,8 @@ public class CrashSender {
   final long millisecondTimestamp;
   @NonNull final String uuid;
   @NonNull final Resource resource;
+  @NonNull final String traceId;
+  @NonNull final String spanId;
 
   /**
    * Creates an object that can send crash reports.
@@ -30,12 +33,16 @@ public class CrashSender {
    * @param crashReport the {@link CrashReport} to send.
    */
   public CrashSender(@NonNull final CrashReport crashReport,
-                     @NonNull final Resource resource) {
+                     @NonNull final Resource resource,
+                     @NonNull final String traceId,
+                     @NonNull final String spanId) {
 
     this.crashReport = crashReport;
     this.millisecondTimestamp = TraceClock.getCurrentTimeMillis();
     this.uuid = UniqueIdGenerator.makeCrashReportId();
     this.resource = resource;
+    this.traceId = traceId;
+    this.spanId = spanId;
   }
 
   /**
@@ -48,8 +55,8 @@ public class CrashSender {
         crashReport.getDescription(),
         TraceClock.createCrashRequestFormat(millisecondTimestamp, TimeZone.getDefault()),
         this.uuid,
-        "",
-        "",
+        traceId,
+        spanId,
         crashReport.getAllExceptionNames()
     );
 

--- a/trace-sdk/src/main/java/io/bitrise/trace/utils/TraceClock.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/utils/TraceClock.java
@@ -43,6 +43,16 @@ public class TraceClock {
   }
 
   /**
+   * Converts a {@link Timestamp} object back to milliseconds - which can be useful for comparison.
+   *
+   * @param timestamp the {@link Timestamp} object with seconds and nanos.
+   * @return the timestamp in milliseconds.
+   */
+  public static long timestampToMillis(@NonNull final Timestamp timestamp) {
+    return (timestamp.getSeconds() * 1000) + (timestamp.getNanos() / 1000 / 1000);
+  }
+
+  /**
    * Gets the current {@link Timestamp}.
    *
    * @return the current Timestamp.

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/collector/view/ActivityStateDataListenerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/collector/view/ActivityStateDataListenerTest.java
@@ -3,10 +3,18 @@ package io.bitrise.trace.data.collector.view;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import android.app.Activity;
 import android.content.Context;
+import io.bitrise.trace.data.dto.ActivityData;
+import io.bitrise.trace.data.dto.ActivityState;
+import io.bitrise.trace.data.dto.Data;
+import io.bitrise.trace.data.management.DataManager;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 /**
@@ -37,6 +45,46 @@ public class ActivityStateDataListenerTest {
     listener.onActivityStopped(mockActivity);
     assertFalse(listener.isActive());
     assertEquals(listener.activityMap.size(), 0);
+  }
+
+  @Test
+  public void stopCollecting_shouldEndAnyOpenActivities() {
+
+    final ActivityStateDataListener listener = new ActivityStateDataListener(mockContext);
+    final DataManager mockDataManager = Mockito.mock(DataManager.class);
+    listener.setDataManager(mockDataManager);
+
+    listener.updateActivityMap(
+        mockActivity.hashCode(),
+        mockActivity.getClass().getSimpleName(),
+        ActivityState.CREATED);
+
+    listener.updateActivityMap(
+        mockActivity.hashCode(),
+        mockActivity.getClass().getSimpleName(),
+        ActivityState.STARTED);
+
+    assertEquals(1, listener.activityMap.size());
+    assertEquals(2, listener.activityMap.get(mockActivity.hashCode()).getStateMap().size());
+
+    listener.stopCollecting();
+
+    // assert that a record was added to the state map.
+    assertEquals(1, listener.activityMap.size());
+    assertEquals(3, listener.activityMap.get(mockActivity.hashCode()).getStateMap().size());
+
+    // assert that data manager was notified
+    final ArgumentCaptor<Data> argumentCaptorData = ArgumentCaptor.forClass(Data.class);
+    verify(mockDataManager, times(1))
+        .handleReceivedData(argumentCaptorData.capture());
+
+    final Object actualContent = argumentCaptorData.getValue().getContent();
+    assertTrue(actualContent instanceof ActivityData);
+
+    // verify 3 records are there (created / started / stopped)
+    final ActivityData actualActivityData = (ActivityData) actualContent;
+    assertEquals(3, actualActivityData.getStateMap().size());
+
   }
 
   @Test

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/collector/view/FragmentStateDataListenerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/collector/view/FragmentStateDataListenerTest.java
@@ -485,15 +485,15 @@ public class FragmentStateDataListenerTest {
     activityMap.put(activityHashCode, fragmentMap);
 
     listener.activityFragmentMap = activityMap;
-    assertEquals(1,
-        listener.activityFragmentMap.get(activityHashCode).get(fragmentHashCode).getStates().size());
+    assertEquals(1, listener.activityFragmentMap.get(activityHashCode)
+                                                .get(fragmentHashCode).getStates().size());
 
     // when i call stop
     listener.stopCollecting();
 
     // then the fragment map should be updated
-    assertEquals(2,
-        listener.activityFragmentMap.get(activityHashCode).get(fragmentHashCode).getStates().size());
+    assertEquals(2, listener.activityFragmentMap.get(activityHashCode)
+                                                .get(fragmentHashCode).getStates().size());
 
     // and the data manager called
     final ArgumentCaptor<Data> argumentCaptorData = ArgumentCaptor.forClass(Data.class);

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/management/DataManagerTest.java
@@ -17,12 +17,14 @@ import io.bitrise.trace.data.collector.DataListener;
 import io.bitrise.trace.data.collector.memory.MemoryDataCollector;
 import io.bitrise.trace.data.collector.network.okhttp.OkHttpDataListener;
 import io.bitrise.trace.data.collector.view.ApplicationStartUpDataListener;
+import io.bitrise.trace.data.dto.CrashData;
 import io.bitrise.trace.data.dto.Data;
 import io.bitrise.trace.data.dto.NetworkData;
 import io.bitrise.trace.data.storage.TraceDataStorage;
 import io.bitrise.trace.scheduler.ExecutorScheduler;
 import io.bitrise.trace.scheduler.ServiceScheduler;
 import io.bitrise.trace.session.ApplicationSessionManager;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -204,4 +206,22 @@ public class DataManagerTest {
   }
 
   //endregion
+
+  @Test
+  public void handleReceivedCrash() {
+    // given a crash
+    final CrashData crashData = new CrashData(new RuntimeException(), 0, new HashMap<>());
+    final DataManager mockDataManager = Mockito.mock(DataManager.class,
+        Mockito.CALLS_REAL_METHODS);
+
+    when(mockDataManager.getActiveDataCollectors()).thenReturn(new HashSet<>());
+    when(mockDataManager.getActiveDataListeners()).thenReturn(new HashSet<>());
+
+    // when i call handleReceivedCrash
+    mockDataManager.handleReceivedCrash(crashData);
+
+    // stop collection should be called
+    verify(mockDataManager, times(1)).stopCollection();
+
+  }
 }

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/trace/TraceTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/trace/TraceTest.java
@@ -50,7 +50,7 @@ public class TraceTest {
     final List<Span> spans = new ArrayList<>();
     spans.add(networkSpan);
     final Trace trace = new Trace("trace id", spans);
-    assertNull( trace.getLastActiveViewSpan());
+    assertNull(trace.getLastActiveViewSpan());
   }
 
   @Test

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/trace/TraceTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/trace/TraceTest.java
@@ -1,0 +1,95 @@
+package io.bitrise.trace.data.trace;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.bitrise.trace.session.ApplicationSessionManager;
+import io.bitrise.trace.test.TraceTestProvider;
+import io.bitrise.trace.utils.TraceClock;
+import io.opencensus.proto.trace.v1.Span;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Trace}.
+ */
+public class TraceTest {
+
+  final Span activitySpan = TraceTestProvider.createActivityViewSpan();
+  final Span networkSpan = TraceTestProvider.createNetworkSpan();
+
+  @BeforeClass
+  public static void setUpBeforeClass() {
+    ApplicationSessionManager.getInstance().startSession();
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    ApplicationSessionManager.getInstance().stopSession();
+  }
+
+  @Test
+  public void getLastActiveViewSpan_noSpans() {
+    final Trace trace = new Trace("trace id", new ArrayList<>());
+    assertNull(trace.getLastActiveViewSpan());
+  }
+
+  @Test
+  public void getLastActiveViewSpan_oneSpan_activitySpan() {
+    final List<Span> spans = new ArrayList<>();
+    spans.add(activitySpan);
+    final Trace trace = new Trace("trace id", spans);
+    assertEquals(activitySpan, trace.getLastActiveViewSpan());
+  }
+
+  @Test
+  public void getLastActiveViewSpan_oneSpan_networkSpan() {
+    final List<Span> spans = new ArrayList<>();
+    spans.add(networkSpan);
+    final Trace trace = new Trace("trace id", spans);
+    assertNull( trace.getLastActiveViewSpan());
+  }
+
+  @Test
+  public void getLastActiveViewSpan_twoSpans_oneActivity() {
+    final List<Span> spans = new ArrayList<>();
+    spans.add(networkSpan);
+    spans.add(activitySpan);
+    final Trace trace = new Trace("trace id", spans);
+    assertEquals(activitySpan, trace.getLastActiveViewSpan());
+  }
+
+  @Test
+  public void getLastActiveViewSpan_twoSpans_twoActivities() {
+
+    final Span activitySpan1 = TraceTestProvider
+        .createActivityViewSpan()
+        .toBuilder()
+        .setStartTime(TraceClock.createTimestamp(1628175971214L))
+        .build();
+
+    final Span activitySpan2 = TraceTestProvider
+        .createActivityViewSpan()
+        .toBuilder()
+        .setStartTime(TraceClock.createTimestamp(1728175971214L))
+        .build();
+
+    final List<Span> spans = new ArrayList<>();
+    spans.add(activitySpan1);
+    spans.add(activitySpan2);
+    final Trace trace = new Trace("trace id", spans);
+    assertEquals(activitySpan2, trace.getLastActiveViewSpan());
+  }
+
+  @Test
+  public void getLastActiveViewSpan_twoSpans_noActivitySpan() {
+    final List<Span> spans = new ArrayList<>();
+    spans.add(networkSpan);
+    spans.add(networkSpan);
+    final Trace trace = new Trace("trace id", spans);
+    assertNull(trace.getLastActiveViewSpan());
+  }
+}

--- a/trace-sdk/src/test/java/io/bitrise/trace/utils/TraceClockTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/utils/TraceClockTest.java
@@ -17,6 +17,7 @@ public class TraceClockTest {
   final long dummyMilliseconds1 = 1000;
   final long dummyMilliseconds2 = 1999;
   final long dummyMilliseconds3 = 1603374824000L;
+  final long dummyMilliseconds4 = 1628173584882L;
 
   /**
    * Check if the result of a milliseconds value is divided by 1000.
@@ -83,6 +84,14 @@ public class TraceClockTest {
         Timestamp.newBuilder().setSeconds(1603374824L).setNanos(0).build();
     final Timestamp actualValue = TraceClock.createTimestamp(dummyMilliseconds3);
     assertThat(actualValue, is(equalTo(expectedValue)));
+  }
+
+  @Test
+  public void getTimeStamp_convertsBothWaysWithRealDate() {
+    final Timestamp expectedTimestamp =
+        Timestamp.newBuilder().setSeconds(1628173584L).setNanos(882000000).build();
+    assertEquals(expectedTimestamp, TraceClock.createTimestamp(dummyMilliseconds4));
+    assertEquals(dummyMilliseconds4, TraceClock.timestampToMillis(expectedTimestamp));
   }
 
   @Test


### PR DESCRIPTION
This PR adds trace ids and span ids to crash reports.

This required stopping all listeners, and ensuring the stopped listeners close and send their data to the data manager.

Have confirmed this works as expected with the pineapple app as this is now the metadata that gets sent:

> 2021-08-06 14:02:05.475 22649-22649/com.example.simpleapplication E/TraceSdk: {"description":"","spanId":"60fff68c50fd4150","throwableClassName":"java.lang.RuntimeException","timestamp":"2021-08-06T14:02:05+01:00","traceId":"81cead44568b42898a40f04009f6db57","uuid":"403d538c-de09-468b-91b3-0c4769b833d0"}

Note: There is still a bug that when the app crashes - the sdk does not actually save the trace or spans. 