### PR TITLE
feat: send crashes on next start up

### DIFF
--- a/trace-sdk/schemas/io.bitrise.trace.data.storage.TraceDatabase/2.json
+++ b/trace-sdk/schemas/io.bitrise.trace.data.storage.TraceDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "3b23897323b1e59e144b07135503374d",
+    "identityHash": "314dec443482a8e1b39c7b955124e0a7",
     "entities": [
       {
         "tableName": "TraceEntity",
@@ -120,7 +120,7 @@
       },
       {
         "tableName": "CrashEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `crashRequest` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `crashRequest` TEXT NOT NULL, `sentAttempts` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -132,6 +132,12 @@
             "fieldPath": "crashRequest",
             "columnName": "crashRequest",
             "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentAttempts",
+            "columnName": "sentAttempts",
+            "affinity": "INTEGER",
             "notNull": true
           }
         ],
@@ -148,7 +154,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3b23897323b1e59e144b07135503374d')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '314dec443482a8e1b39c7b955124e0a7')"
     ]
   }
 }

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/CrashStorageInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/CrashStorageInstrumentedTest.java
@@ -167,6 +167,22 @@ public class CrashStorageInstrumentedTest {
   }
 
   @Test
+  public void updateCrashRequest_idDoesNotExist() {
+    // given a crash request in the data store
+    final CrashRequest request1 = createCrashRequest("uuid1", 1628778619944L);
+    dataStorage.saveCrashRequest(request1);
+
+    // verify there is only one record
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+
+    // update the counter for a crash that doesn't exist
+    dataStorage.updateCrashRequestSentAttemptCounter("uuid2");
+
+    // verify there is still one record
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+  }
+
+  @Test
   public void updateCrashRequestMaxAttempts() {
     // given a crash request in the data store
     final CrashRequest request = createCrashRequest("uuid1", 1628778619944L);

--- a/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/CrashStorageInstrumentedTest.java
+++ b/trace-sdk/src/androidTest/java/io/bitrise/trace/data/storage/CrashStorageInstrumentedTest.java
@@ -146,5 +146,49 @@ public class CrashStorageInstrumentedTest {
     assertTrue(updatedRequests.contains(request2));
   }
 
+  @Test
+  public void updateCrashRequest() {
+    // given a crash request in the data store
+    final CrashRequest request1 = createCrashRequest("uuid1", 1628778619944L);
+    dataStorage.saveCrashRequest(request1);
+
+    // verify there is only one record
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+
+    // update the counter
+    dataStorage.updateCrashRequestSentAttemptCounter(request1.getMetadata().getUuid());
+
+    // verify there is still one record
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+
+    // verify our crash entity increased attempts
+    final CrashEntity crashEntity = dataStorage.getCrashEntity(request1.getMetadata().getUuid());
+    assertEquals(1, crashEntity.getSentAttempts());
+  }
+
+  @Test
+  public void updateCrashRequestMaxAttempts() {
+    // given a crash request in the data store
+    final CrashRequest request = createCrashRequest("uuid1", 1628778619944L);
+    dataStorage.saveCrashRequest(request);
+
+    // verify there is only one record
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+
+    // update the counter 4 times
+    dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
+    dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
+    dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
+    dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
+
+    // verify there are still records
+    assertEquals(1, dataStorage.getAllCrashRequests().size());
+
+    // update one final time
+    dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
+
+    // verify there are no records left
+    assertEquals(0, dataStorage.getAllCrashRequests().size());
+  }
 
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/TraceSdk.java
@@ -9,6 +9,8 @@ import io.bitrise.trace.configuration.ConfigurationManager;
 import io.bitrise.trace.data.TraceActivityLifecycleTracker;
 import io.bitrise.trace.data.collector.network.urlconnection.TraceURLStreamHandlerFactory;
 import io.bitrise.trace.data.management.DataManager;
+import io.bitrise.trace.data.management.StartupMonitor;
+import io.bitrise.trace.data.storage.TraceDataStorage;
 import io.bitrise.trace.data.trace.ApplicationTraceManager;
 import io.bitrise.trace.session.ApplicationSessionManager;
 import io.bitrise.trace.session.SessionManager;
@@ -91,6 +93,7 @@ public class TraceSdk {
       initLifeCycleListener(context);
       initNetworkTracing(options);
       TraceLog.i(String.format(LogMessageConstants.TRACE_DEBUG_FLAG_STATUS, isDebugModeEnabled));
+      StartupMonitor.checkSavedCrashes(TraceDataStorage.getInstance(context));
     } else {
       TraceLog.e(new TraceException.TraceConfigNotInitialisedException());
     }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/management/StartupMonitor.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/management/StartupMonitor.java
@@ -1,0 +1,42 @@
+package io.bitrise.trace.data.management;
+
+import io.bitrise.trace.data.storage.DataStorage;
+import io.bitrise.trace.network.CrashRequest;
+import io.bitrise.trace.network.CrashSender;
+import io.bitrise.trace.utils.log.TraceLog;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
+
+/**
+ * Object that can check if there is any data in the data storage that needs to be actioned on
+ * application start up.
+ * e.g. sending any crashes that were previously saved.
+ */
+public abstract class StartupMonitor {
+
+  /**
+   * Checks if there are any saved crash requests and sends them.
+   *
+   * @param dataStorage the current trace data storage.
+   */
+  public static void checkSavedCrashes(@Nonnull final DataStorage dataStorage) {
+
+    final ExecutorService service = Executors.newFixedThreadPool(1);
+    service.submit(() -> {
+      final List<CrashRequest> savedRequests = dataStorage.getAllCrashRequests();
+
+      if (savedRequests.isEmpty()) {
+        TraceLog.d("No saved crash requests to send.");
+        return;
+      }
+
+      TraceLog.d("Number of crash requests saved: " + savedRequests.size());
+
+      for (CrashRequest request : savedRequests) {
+        new CrashSender(request, dataStorage).send();
+      }
+    });
+  }
+}

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/storage/CrashDao.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/storage/CrashDao.java
@@ -6,6 +6,7 @@ import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import io.bitrise.trace.data.storage.entities.CrashEntity;
+import io.bitrise.trace.network.CrashRequest;
 import java.util.List;
 
 /**
@@ -22,6 +23,15 @@ public interface CrashDao  {
   @NonNull
   @Query("SELECT * FROM CrashEntity")
   List<CrashEntity> getAll();
+
+  /**
+   * Gets a {@link CrashEntity} by uuid.
+   *
+   * @param id the uuid as specified in the {@link CrashRequest.Metadata}.
+   * @return the crash entity, or null if it cannot be found.
+   */
+  @Query("SELECT * FROM CrashEntity WHERE id = :id")
+  CrashEntity getById(@NonNull String id);
 
   /**
    * Inserts the given {@link CrashEntity}s to the database. Replaces if there is a conflict.

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/storage/DataStorage.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/storage/DataStorage.java
@@ -430,10 +430,12 @@ public abstract class DataStorage {
 
     if (crashEntity != null) {
       crashEntity.updateSentAttempts();
-
       if (crashEntity.getSentAttempts() < 5) {
+        TraceLog.d("Updating crash request: failed attempts to send: "
+            + crashEntity.getSentAttempts());
         traceDatabase.getCrashDao().insert(crashEntity);
       } else {
+        TraceLog.d("Crash request reached maximum attempts to send, will be deleted.");
         deleteCrashRequest(id);
       }
     }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/storage/entities/CrashEntity.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/storage/entities/CrashEntity.java
@@ -22,6 +22,8 @@ public class CrashEntity {
   @NonNull
   private final CrashRequest crashRequest;
 
+  private int sentAttempts;
+
   /**
    * Create a {@link CrashEntity} to save to storage.
    *
@@ -31,12 +33,19 @@ public class CrashEntity {
   public CrashEntity(@NonNull String id, @NonNull CrashRequest crashRequest) {
     this.id = id;
     this.crashRequest = crashRequest;
+    sentAttempts = 0;
   }
 
+  /**
+   * Creates a {@link CrashEntity} to save to storage.
+   *
+   * @param crashRequest the {@link CrashRequest} object to hold.
+   */
   @Ignore
   public CrashEntity(@NonNull CrashRequest crashRequest) {
     this.id = crashRequest.getMetadata().getUuid();
     this.crashRequest = crashRequest;
+    sentAttempts = 0;
   }
 
   @NonNull
@@ -47,5 +56,21 @@ public class CrashEntity {
   @NonNull
   public CrashRequest getCrashRequest() {
     return crashRequest;
+  }
+
+  /**
+   * Update the counter for the number of attempts this request has tried to send.
+   */
+  public void updateSentAttempts() {
+    this.sentAttempts++;
+  }
+
+  /**
+   * Gets the current number of attempts to send the request.
+   *
+   * @return the number of attempts to send the request.
+   */
+  public int getSentAttempts() {
+    return sentAttempts;
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/data/storage/entities/CrashEntity.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/data/storage/entities/CrashEntity.java
@@ -73,4 +73,13 @@ public class CrashEntity {
   public int getSentAttempts() {
     return sentAttempts;
   }
+
+  /**
+   * Sets the number of attempts to send a request.
+   *
+   * @param sentAttempts the number of attempts so far.
+   */
+  public void setSentAttempts(int sentAttempts) {
+    this.sentAttempts = sentAttempts;
+  }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/CrashSender.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/CrashSender.java
@@ -1,7 +1,11 @@
 package io.bitrise.trace.network;
 
 import androidx.annotation.NonNull;
+import io.bitrise.trace.data.storage.DataStorage;
 import io.bitrise.trace.utils.log.TraceLog;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -12,14 +16,17 @@ import retrofit2.Response;
 public class CrashSender {
 
   @NonNull final CrashRequest request;
+  @NonNull final DataStorage dataStorage;
 
   /**
    * Creates an object that can send crash reports.
    *
    * @param request - the {@link CrashRequest} object to send.
    */
-  public CrashSender(@NonNull final CrashRequest request) {
+  public CrashSender(@NonNull final CrashRequest request,
+                     @Nonnull final DataStorage dataStorage) {
     this.request = request;
+    this.dataStorage = dataStorage;
   }
 
   /**
@@ -33,8 +40,10 @@ public class CrashSender {
         if (response.isSuccessful()) {
           TraceLog.d("Crash report sent successfully: "
               + response.headers().get("correlation-id"));
+          removeCrash();
         } else {
           TraceLog.e("Crash report failed to send: " + response.code());
+          updateSentAttemptsCounter();
         }
       }
 
@@ -42,7 +51,22 @@ public class CrashSender {
       public void onFailure(@NonNull final Call<Void> call,
                             @NonNull final Throwable t) {
         TraceLog.e("Crash report failed to send: " + t.getLocalizedMessage());
+        updateSentAttemptsCounter();
       }
+    });
+  }
+
+  private void removeCrash() {
+    final ExecutorService service = Executors.newFixedThreadPool(1);
+    service.submit(() -> {
+      dataStorage.deleteCrashRequest(request.getMetadata().getUuid());
+    });
+  }
+
+  private void updateSentAttemptsCounter() {
+    final ExecutorService service = Executors.newFixedThreadPool(1);
+    service.submit(() -> {
+      dataStorage.updateCrashRequestSentAttemptCounter(request.getMetadata().getUuid());
     });
   }
 }

--- a/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkClient.java
+++ b/trace-sdk/src/main/java/io/bitrise/trace/network/NetworkClient.java
@@ -3,6 +3,7 @@ package io.bitrise.trace.network;
 import android.os.Build;
 import android.os.LocaleList;
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -67,7 +68,8 @@ public final class NetworkClient {
   /**
    * The {@link NetworkCommunicator} interface of this client.
    */
-  private static volatile NetworkCommunicator networkCommunicator;
+  @VisibleForTesting
+  static volatile NetworkCommunicator networkCommunicator;
 
   /**
    * Constructor to prevent instantiation outside of the class.

--- a/trace-sdk/src/test/java/io/bitrise/trace/data/CrashTestDataProvider.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/data/CrashTestDataProvider.java
@@ -1,5 +1,6 @@
 package io.bitrise.trace.data;
 
+import androidx.annotation.NonNull;
 import io.bitrise.trace.data.dto.CrashReport;
 import io.bitrise.trace.network.CrashRequest;
 import io.bitrise.trace.test.DataTestUtils;
@@ -116,12 +117,21 @@ public class CrashTestDataProvider {
    * @return the test crash request object.
    */
   public static CrashRequest createCrashRequest() {
+    return createCrashRequestWithUuid("uuid");
+  }
+
+  /**
+   * Creates a test {@link CrashRequest} with a given uuid.
+   *
+   * @return the test crash request object.
+   */
+  public static CrashRequest createCrashRequestWithUuid(@NonNull final String uuid) {
     return new CrashRequest(
         DataTestUtils.getSampleResource("session-id"),
         createCrashReport(),
         1629292193024L,
         TimeZone.getTimeZone("Europe/London"),
-        "uuid",
+        uuid,
         "trace-id",
         "spanid"
     );

--- a/trace-sdk/src/test/java/io/bitrise/trace/network/CrashSenderTest.java
+++ b/trace-sdk/src/test/java/io/bitrise/trace/network/CrashSenderTest.java
@@ -1,0 +1,114 @@
+package io.bitrise.trace.network;
+
+import static java.lang.Thread.sleep;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.bitrise.trace.data.CrashTestDataProvider;
+import io.bitrise.trace.data.storage.DataStorage;
+import java.io.IOException;
+import okhttp3.ResponseBody;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Unit tests for {@link CrashSender}.
+ */
+public class CrashSenderTest {
+
+  final NetworkCommunicator mockCommunicator = Mockito.mock(NetworkCommunicator.class);
+  final DataStorage mockDataStorage = Mockito.mock(DataStorage.class);
+
+  @Before
+  public void setup() {
+    NetworkClient.networkCommunicator = mockCommunicator;
+  }
+
+  @After
+  public void tearDown() {
+    NetworkClient.networkCommunicator = null;
+  }
+
+  @Test
+  public void send_isSuccessful() throws InterruptedException {
+    final CrashSender sender = new CrashSender(
+        CrashTestDataProvider.createCrashRequestWithUuid("uuid1"), mockDataStorage);
+
+    final Call<Void> mockedCall = Mockito.mock(Call.class);
+    Mockito.when(mockCommunicator.sendCrash(any())).thenReturn(mockedCall);
+
+    Mockito.doAnswer(invocation -> {
+      Callback<Void> callback = invocation.getArgument(0, Callback.class);
+      callback.onResponse(mockedCall, Response.success(null));
+      return null;
+    }).when(mockedCall).enqueue(any(Callback.class));
+
+    // when i call send
+    sender.send();
+
+    // this happens asynchronously, and can take a few milliseconds to actually get called.
+    sleep(100);
+
+    // the request should be removed
+    verify(mockDataStorage, times(1))
+        .deleteCrashRequest("uuid1");
+  }
+
+  @Test
+  public void send_isNotSuccessful() throws InterruptedException {
+    final CrashSender sender = new CrashSender(
+        CrashTestDataProvider.createCrashRequestWithUuid("uuid2"), mockDataStorage);
+
+    final Call<Void> mockedCall = Mockito.mock(Call.class);
+    Mockito.when(mockCommunicator.sendCrash(any())).thenReturn(mockedCall);
+
+    Mockito.doAnswer(invocation -> {
+      Callback<Void> callback = invocation.getArgument(0, Callback.class);
+      final ResponseBody mockResponseBody = Mockito.mock(ResponseBody.class);
+      callback.onResponse(mockedCall, Response.error(503, mockResponseBody));
+      return null;
+    }).when(mockedCall).enqueue(any(Callback.class));
+
+    // when i call send
+    sender.send();
+
+    // this happens asynchronously, and can take a few milliseconds to actually get called.
+    sleep(100);
+
+    // the request should be removed
+    verify(mockDataStorage, times(1))
+        .updateCrashRequestSentAttemptCounter("uuid2");
+  }
+
+  @Test
+  public void send_onFailure() throws InterruptedException {
+    final CrashSender sender = new CrashSender(
+        CrashTestDataProvider.createCrashRequestWithUuid("uuid3"), mockDataStorage);
+
+    final Call<Void> mockedCall = Mockito.mock(Call.class);
+    Mockito.when(mockCommunicator.sendCrash(any())).thenReturn(mockedCall);
+
+    Mockito.doAnswer(invocation -> {
+      Callback<Void> callback = invocation.getArgument(0, Callback.class);
+      callback.onFailure(mockedCall, new IOException());
+      return null;
+    }).when(mockedCall).enqueue(any(Callback.class));
+
+    // when i call send
+    sender.send();
+
+    // this happens asynchronously, and can take a few milliseconds to actually get called.
+    sleep(100);
+
+    // the request should be removed
+    verify(mockDataStorage, times(1))
+        .updateCrashRequestSentAttemptCounter("uuid3");
+  }
+
+}


### PR DESCRIPTION
this pr adds as a StartupMonitor that sends any crash reports on startup.

It also updates the CrashEntity to keep track how many times a request is attempted to send, and deletes it after 5 failed attempts.